### PR TITLE
Allow special characters to be escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Within a block of text:
 
 * `/words/` becomes `<em>words</em>`
 * `*words*` becomes `<strong>words</strong>`
-* `~words~` becomes `<s>words</s>`
 * `_words_` becomes `<mark>words</mark>`
+* ``words`` becomes `<code>words</code>`
+* `~words~` becomes `<s>words</s>`
 
 Whereas blocks look like:
 

--- a/README.sax
+++ b/README.sax
@@ -71,6 +71,7 @@ Within a block of text:
 * `*words*` becomes `<strong>words</strong>`
 * `~words~` becomes `<s>words</s>`
 * `_words_` becomes `<mark>words</mark>`
+* `\`words\`` becomes `<code>words</code>`
 
 Whereas blocks look like:
 

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -4,7 +4,7 @@ sealed abstract class Node {
   def children: Traversable[Node]
   val label = "node"
   def label_display = s"$label"
-  override def toString = s"<$label_display>${children.foldLeft("")((prev, current) => prev + current.toString)}</$label>"
+  override def toString = s"<$label_display>${children.mkString("")}</$label>"
 }
 
 case class Document(children: Seq[Node]) extends Node {
@@ -28,7 +28,7 @@ case class ForcedNewline() extends Node {
 case class Code(directives: Map[String, String], contents:String) extends Node {
   val children = Seq.empty
   override val label = "code"
-  override def toString = s"""<$label ${(directives map {case (k, v) => s"""$k="$v""""}).foldLeft("")((prev, current) => s"$prev $current")}>$contents</$label>"""
+  override def toString = s"""<$label ${(directives map {case (k, v) => s"""$k="$v""""}).mkString(" ")}>$contents</$label>"""
 }
 
 case class Quote(children: Seq[Node], source: Option[Seq[InlineNode]]) extends Node {


### PR DESCRIPTION
For example, i should be able to write "I want to be a *" and have saxophone
output "I want to be a *". Similarly, "`\`how to monospace``" should put 
"`how to monospace`" in a MonospacedText node.
