### PR TITLE
Possibly unescaped segments of text

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -70,6 +70,10 @@ case class Footnote(children: Seq[Node]) extends InlineNode {
   override val label = "foot"
 }
 
+case class RawText(text:String) extends InlineNode {
+  val children = Seq.empty[Node]
+  override def toString = "<raw>" + text + "</raw>"
+}
 
 trait TransformedText extends InlineNode {
   val children = Seq.empty[Node]

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -34,6 +34,7 @@ trait BaseTranslator {
   def underlinedText(node:UnderlinedText): String
   def weightedText(node:WeightedText): String
   def monospacedText(node:MonospaceText): String
+  def rawText(node:RawText): String
 
   def node_to_translator(n:Node) = n match {
     case n: StandardText => standardText(n)
@@ -48,6 +49,7 @@ trait BaseTranslator {
     case n: StruckthroughText => struckthroughText(n)
     case n: UnderlinedText => underlinedText(n)
     case n: MonospaceText => monospacedText(n)
+    case n: RawText => rawText(n)
     case n: Quote => quote(n)
     case n => this.node(n)
   }

--- a/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
@@ -21,6 +21,8 @@ class GithubMDTranslator extends BaseTranslator {
 
   override def forcedNewLine(node: ForcedNewline): String = "\n\n"
 
+  override def rawText(node: RawText): String = node.text
+
   override def unorderedList(node: UnorderedList): String = {
     ((for (line <- node.items) yield s"* ${line.map(translate(_)).mkString}") mkString "\n") + "\n\n"
   }

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -5,7 +5,10 @@ import com.haaksmash.saxophone.primitives._
 import scala.collection.immutable.ListMap
 
 
-class HTMLTranslator(wrap_code_with_pre: Boolean = true) extends BaseTranslator {
+class HTMLTranslator(
+  wrap_code_with_pre:Boolean=true,
+  allow_raw_strings:Boolean=true
+) extends BaseTranslator {
 
   /*
    * These are block-level nodes; i.e., nodes that should have their
@@ -55,7 +58,7 @@ class HTMLTranslator(wrap_code_with_pre: Boolean = true) extends BaseTranslator 
   def underlinedText(node:UnderlinedText) = s"""<mark>${escapeTextForHTML(node.text)}</mark>"""
   def weightedText(node:WeightedText) = s"<strong>${escapeTextForHTML(node.text)}</strong>"
   def monospacedText(node:MonospaceText) = s"<code>${escapeTextForHTML(node.text)}</code>"
-  def rawText(node: RawText) = node.text
+  def rawText(node: RawText) = if (allow_raw_strings) node.text else escapeTextForHTML(node.text)
 
 
   /**

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -55,6 +55,8 @@ class HTMLTranslator(wrap_code_with_pre: Boolean = true) extends BaseTranslator 
   def underlinedText(node:UnderlinedText) = s"""<mark>${escapeTextForHTML(node.text)}</mark>"""
   def weightedText(node:WeightedText) = s"<strong>${escapeTextForHTML(node.text)}</strong>"
   def monospacedText(node:MonospaceText) = s"<code>${escapeTextForHTML(node.text)}</code>"
+  def rawText(node: RawText) = node.text
+
 
   /**
    * Escapes a string so that it's safe for HTML; e.g., replacing {@code <} with {@code &amp;lt;}.

--- a/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
@@ -37,6 +37,8 @@ class SaxophoneTreeStringTranslator extends BaseTranslator {
 
   override def code(node: Code): String = ???
 
+  override def rawText(node: RawText): String = ???
+
   override def monospacedText(node: MonospaceText): String = ???
 
   override def translate(document: Node) = {

--- a/src/test/resources/article_example.sax
+++ b/src/test/resources/article_example.sax
@@ -19,6 +19,7 @@ and an unordered list:
 ## subheading here.
 
 _this text is underlined_, whereas ~this text is struck-through~. *this text is bolded*, whereas /this text is italicized/.
+and =this text is <raw/>= unlike <here>!
 
 In this paragraph, at long last, we come to the important part: `the code` (this last should appear monospaced).
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
@@ -1,6 +1,6 @@
 package com.haaksmash.saxophone.parsers
 
-import com.haaksmash.saxophone.primitives.StandardText
+import com.haaksmash.saxophone.primitives.{RawText, StandardText}
 import org.scalatest._
 
 class InlineParsersSpec extends FlatSpec {
@@ -53,6 +53,13 @@ class InlineParsersSpec extends FlatSpec {
     val result = parsers.parseAll(parsers.standardText(Set()), input).get
 
     assert(result.text == "`hello`")
+  }
+
+  "raw_text" should "match characters between =" in {
+    val input = "=`*RAW*`="
+    val result = parsers.parseAll(parsers.raw_text, input).get
+
+    assert(result.text == "`*RAW*`")
   }
 
   "emphasized_text" should "match characters between /" in {
@@ -167,10 +174,17 @@ class InlineParsersSpec extends FlatSpec {
   }
 
   it should "prevent nesting" in {
-    for ((s:Char,(f:String, e:Char)) <- parsers.special_char_to_tracking_and_ending_char) {
+    for ((s, (f:String, e)) <- parsers.special_char_to_tracking_and_ending_char) {
       val nested_result = parsers.parseAll(parsers.element(visited = Set(f)), s"${s}hello$e")
 
       assert(nested_result.isEmpty)
     }
   }
+
+  "elements" should "recognize raw marker strings" in {
+    val raw_result = parsers.parseAll(parsers.elements(), "and =this is **RAW**=")
+    assert(!raw_result.isEmpty)
+    assert(raw_result.get == Seq(StandardText("and "), RawText("this is **RAW**")))
+  }
+
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
@@ -153,6 +153,13 @@ class GithubMDTranslatorSpec extends FlatSpec {
     assert(result == "defective link")
   }
 
+  "rawText" should "translate a RawText" in {
+    val text = RawText("<`ha`/>")
+    val result = translator.rawText(text)
+
+    assert(result == "<`ha`/>")
+  }
+
   "forcedNewline" should "translate a ForcedNewLine" in {
     val text = ForcedNewline()
 

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -208,6 +208,13 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == "<mark>defective link</mark>")
   }
 
+  "rawText" should "translate a RawText" in {
+    val text = RawText("<hohoho>")
+    val result = translator.rawText(text)
+
+    assert(result == "<hohoho>")
+  }
+
   it should "escape its text" in {
 
     val text = UnderlinedText("<look> &<a tag>")

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -215,6 +215,13 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == "<hohoho>")
   }
 
+  it should "escape the RawText if told to do so" in {
+    val text = RawText("<hohoho>")
+    val result = new HTMLTranslator(allow_raw_strings = false).rawText(text)
+
+    assert(result == "&lt;hohoho&gt;")
+  }
+
   it should "escape its text" in {
 
     val text = UnderlinedText("<look> &<a tag>")


### PR DESCRIPTION
Adds support for RawText inline nodes (between `=`), which indicate that this
section of text should be emitted verbatim by the translator. HTMLTranslator
has a new option to honor or ignore that indication.
