### PR TITLE
Footnote output in HTML

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
 
 scalaVersion := "2.11.4"
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test"
 

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -84,7 +84,7 @@ case class UnorderedList(items: Set[Seq[Node]]) extends ListNode(items){
 trait InlineNode extends Node
 
 
-case class Footnote(children: Seq[Node]) extends InlineNode {
+case class Footnote(children: Seq[InlineNode]) extends InlineNode {
   override val label = "foot"
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -69,6 +69,7 @@ trait BaseTranslator {
     case n: MonospaceText => monospacedText(n)
     case n: RawText => rawText(n)
     case n: Quote => quote(n)
+    case n: Footnote => footnote(n)
     case n => this.node(n)
   }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -25,8 +25,7 @@ import scala.collection.immutable.ListMap
 
 class HTMLTranslator(
   allow_raw_strings:Boolean=true,
-  footnote_as_title_text:Boolean=false,
-  footnote_inline:Boolean=false
+  footnote_as_title_text:Boolean=false
 ) extends BaseTranslator {
 
   var footnotes = Seq[String]()
@@ -66,12 +65,9 @@ class HTMLTranslator(
       footnotes = footnotes :+ ""
       val title_text = translate(node).replaceAll("\"", "\\\\\"")
       s"""<a title="${title_text}" rel="footnote">$footnote_number</a>"""
-    } else if (footnote_inline) {
-      footnotes = footnotes :+ ""
-      s"""<aside num=$footnote_number>${translate(node)}</aside>"""
     } else {
       footnotes = footnotes :+ translate(node)
-      s"""<a href="#fn$footnote_number" name="rn$footnote_number" rel="footnote">$footnote_number</a>"""
+      s"""<a href="#note:$footnote_number" name="rn:$footnote_number" rel="footnote">$footnote_number</a>"""
     }
   }
 
@@ -94,8 +90,8 @@ class HTMLTranslator(
     val s = super.translate(node)
 
     val footer_string = node match {
-      case n:Document if !footnotes.isEmpty && !(footnote_as_title_text || footnote_inline) =>
-        "<footer>" + footnotes.zipWithIndex.map { case (note, num) => s"""<p><a class="fnote" href="#rn${num + 1}" name="fn${num + 1}">${num + 1}</a> $note</p>"""}.mkString + "</footer>"
+      case n:Document if !footnotes.isEmpty && !(footnote_as_title_text) =>
+        "<footer>" + footnotes.zipWithIndex.map { case (note, num) => s"""<p><a class="fnote" href="#rn:${num + 1}" name="note:${num + 1}">${num + 1}</a> $note</p>"""}.mkString + "</footer>"
       case _ => ""
     }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -26,7 +26,8 @@ import scala.collection.immutable.ListMap
 class HTMLTranslator(
   wrap_code_with_pre:Boolean=true,
   allow_raw_strings:Boolean=true,
-  footnotes_as_title_text:Boolean=false
+  footnote_as_title_text:Boolean=false,
+  footnote_inline:Boolean=false
 ) extends BaseTranslator {
 
   var footnotes = Seq[String]()
@@ -67,13 +68,16 @@ class HTMLTranslator(
 
   def footnote(node:Footnote) = {
     val footnote_number = footnotes.size + 1
-    if (footnotes_as_title_text){
+    if (footnote_as_title_text) {
       footnotes = footnotes :+ ""
       val title_text = translate(node).replaceAll("\"", "\\\\\"")
-      s"""<sup><a title="${title_text}">$footnote_number</a></sup>"""
+      s"""<a title="${title_text}" rel="footnote">$footnote_number</a>"""
+    } else if (footnote_inline) {
+      footnotes = footnotes :+ ""
+      s"""<aside num=$footnote_number>${translate(node)}</aside>"""
     } else {
       footnotes = footnotes :+ translate(node)
-      s"""<sup><a href="#fn$footnote_number" name="rn$footnote_number">$footnote_number</a></sup>"""
+      s"""<a href="#fn$footnote_number" name="rn$footnote_number" rel="footnote">$footnote_number</a>"""
     }
   }
 
@@ -96,7 +100,7 @@ class HTMLTranslator(
     val s = super.translate(node)
 
     val footer_string = node match {
-      case n:Document if !footnotes.isEmpty && !footnotes_as_title_text =>
+      case n:Document if !footnotes.isEmpty && !(footnote_as_title_text || footnote_inline) =>
         "<footer>" + footnotes.zipWithIndex.map { case (note, num) => s"""<p><a class="fnote" href="#rn${num + 1}" name="fn${num + 1}">${num + 1}</a> $note</p>"""}.mkString + "</footer>"
       case _ => ""
     }

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -25,7 +25,8 @@ import scala.collection.immutable.ListMap
 
 class HTMLTranslator(
   wrap_code_with_pre:Boolean=true,
-  allow_raw_strings:Boolean=true
+  allow_raw_strings:Boolean=true,
+  footnotes_as_title_text:Boolean=false
 ) extends BaseTranslator {
 
   var footnotes = Seq[String]()
@@ -66,8 +67,14 @@ class HTMLTranslator(
 
   def footnote(node:Footnote) = {
     val footnote_number = footnotes.size + 1
-    footnotes = footnotes :+ translate(node)
-    s"""<sup><a href="#fn$footnote_number" name="rn$footnote_number">$footnote_number</a></sup>"""
+    if (footnotes_as_title_text){
+      footnotes = footnotes :+ ""
+      val title_text = translate(node).replaceAll("\"", "\\\\\"")
+      s"""<sup><a title="${title_text}">$footnote_number</a></sup>"""
+    } else {
+      footnotes = footnotes :+ translate(node)
+      s"""<sup><a href="#fn$footnote_number" name="rn$footnote_number">$footnote_number</a></sup>"""
+    }
   }
 
   /*
@@ -89,7 +96,7 @@ class HTMLTranslator(
     val s = super.translate(node)
 
     val footer_string = node match {
-      case n:Document if !footnotes.isEmpty =>
+      case n:Document if !footnotes.isEmpty && !footnotes_as_title_text =>
         "<footer>" + footnotes.zipWithIndex.map { case (note, num) => s"""<p><a class="fnote" href="#rn${num + 1}" name="fn${num + 1}">${num + 1}</a> $note</p>"""}.mkString + "</footer>"
       case _ => ""
     }

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -24,7 +24,6 @@ import scala.collection.immutable.ListMap
 
 
 class HTMLTranslator(
-  wrap_code_with_pre:Boolean=true,
   allow_raw_strings:Boolean=true,
   footnote_as_title_text:Boolean=false,
   footnote_inline:Boolean=false
@@ -39,28 +38,23 @@ class HTMLTranslator(
   def heading(node:Heading) = s"""<h${node.level}>${translate(node)}</h${node.level}>"""
   def paragraph(node:Paragraph) = s"""<p>${translate(node)}</p>"""
   def code(node:Code) = {
-    val code_contents = {
-      if (wrap_code_with_pre)
-        node.contents
-      else
-        escapeTextForHTML(node.contents)
-    }
-    val code_block = s"""<code${node.directives.foldLeft(""){case (s, (k, v)) => s"""$s $k="$v""""}}>$code_contents</code>"""
-    if (wrap_code_with_pre)
-      s"""<pre>$code_block</pre>"""
-    else
-      code_block
+    val code_contents = escapeTextForHTML(node.contents)
+
+    s"""<figure class="code"><code${node.directives.foldLeft(""){case (s, (k, v)) => s"""$s $k="$v""""}}>$code_contents</code></figure>"""
   }
+
   def quote(node:Quote) = {
     if (node.source.isDefined)
       s"""<blockquote>${translate(node)}<footer>${node.source.get.map(translate(_)).mkString}</footer></blockquote>"""
     else
       s"""<blockquote>${translate(node)}</blockquote>"""
   }
+
   def orderedList(node:OrderedList) = {
     val list_items = node.items.map(li => s"<li>${li.map(translate(_)).mkString}</li>") mkString ""
     s"""<ol>$list_items</ol>"""
   }
+
   def unorderedList(node:UnorderedList) = {
     val list_items = node.items.map(li => s"""<li>${li.map(translate(_)).mkString}</li>""") mkString ""
     s"""<ul>$list_items</ul>"""
@@ -134,6 +128,6 @@ class HTMLTranslator(
 
 object HTMLTranslator {
   def translate(node:Node): String = {
-    new HTMLTranslator(true).translate(node)
+    new HTMLTranslator().translate(node)
   }
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -281,7 +281,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.footnote(text)
 
-    assert(result == "<sup><a href=\"#fn1\" name=\"rn1\">1</a></sup>")
+    assert(result == "<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>")
   }
 
   it should "be emitted at the end of the document" in {
@@ -293,7 +293,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "<p>Greetings, humans<sup><a href=\"#fn1\" name=\"rn1\">1</a></sup>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> humans is here used to refer to any sapient creature</p></footer>")
+    assert(result == "<p>Greetings, humans<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> humans is here used to refer to any sapient creature</p></footer>")
   }
 
   it should "increment its footer numbers, etc" in {
@@ -305,7 +305,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "<p>Greetings,<sup><a href=\"#fn1\" name=\"rn1\">1</a></sup> humans<sup><a href=\"#fn2\" name=\"rn2\">2</a></sup>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> hohoho</p><p><a class=\"fnote\" href=\"#rn2\" name=\"fn2\">2</a> humans is here used to refer to any sapient creature</p></footer>")
+    assert(result == "<p>Greetings,<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a> humans<a href=\"#fn2\" name=\"rn2\" rel=\"footnote\">2</a>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> hohoho</p><p><a class=\"fnote\" href=\"#rn2\" name=\"fn2\">2</a> humans is here used to refer to any sapient creature</p></footer>")
 
   }
 
@@ -318,7 +318,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "Greetings, humans<sup><a href=\"#fn1\" name=\"rn1\">1</a></sup>!")
+    assert(result == "Greetings, humans<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>!")
   }
 
   it should "put alt text instead of footer if told to do so" in {
@@ -328,8 +328,20 @@ class HTMLTranslatorSpec extends FlatSpec {
       StandardText("!")
     ))))
 
-    val result = new HTMLTranslator(footnotes_as_title_text=true).translate(text)
+    val result = new HTMLTranslator(footnote_as_title_text=true).translate(text)
 
-    assert(result == "<p>Greetings, humans<sup><a title=\"humans is here used to refer to any \\\"sapient\\\" creature\">1</a></sup>!</p>")
+    assert(result == "<p>Greetings, humans<a title=\"humans is here used to refer to any \\\"sapient\\\" creature\" rel=\"footnote\">1</a>!</p>")
+  }
+
+  it should "use <aside> if footnote_inline specified" in {
+    val text = Document(Seq(Paragraph(Seq(
+      StandardText("Greetings, humans"),
+      Footnote(Seq(StandardText("humans is here used to refer to any \"sapient\" creature"))),
+      StandardText("!")
+    ))))
+
+    val result = new HTMLTranslator(footnote_inline=true).translate(text)
+
+    assert(result == "<p>Greetings, humans<aside num=1>humans is here used to refer to any \"sapient\" creature</aside>!</p>")
   }
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -320,4 +320,16 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     assert(result == "Greetings, humans<sup><a href=\"#fn1\" name=\"rn1\">1</a></sup>!")
   }
+
+  it should "put alt text instead of footer if told to do so" in {
+    val text = Document(Seq(Paragraph(Seq(
+      StandardText("Greetings, humans"),
+      Footnote(Seq(StandardText("humans is here used to refer to any \"sapient\" creature"))),
+      StandardText("!")
+    ))))
+
+    val result = new HTMLTranslator(footnotes_as_title_text=true).translate(text)
+
+    assert(result == "<p>Greetings, humans<sup><a title=\"humans is here used to refer to any \\\"sapient\\\" creature\">1</a></sup>!</p>")
+  }
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -263,7 +263,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.footnote(text)
 
-    assert(result == "<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>")
+    assert(result == "<a href=\"#note:1\" name=\"rn:1\" rel=\"footnote\">1</a>")
   }
 
   it should "be emitted at the end of the document" in {
@@ -275,7 +275,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "<p>Greetings, humans<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> humans is here used to refer to any sapient creature</p></footer>")
+    assert(result == "<p>Greetings, humans<a href=\"#note:1\" name=\"rn:1\" rel=\"footnote\">1</a>!</p><footer><p><a class=\"fnote\" href=\"#rn:1\" name=\"note:1\">1</a> humans is here used to refer to any sapient creature</p></footer>")
   }
 
   it should "increment its footer numbers, etc" in {
@@ -287,7 +287,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "<p>Greetings,<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a> humans<a href=\"#fn2\" name=\"rn2\" rel=\"footnote\">2</a>!</p><footer><p><a class=\"fnote\" href=\"#rn1\" name=\"fn1\">1</a> hohoho</p><p><a class=\"fnote\" href=\"#rn2\" name=\"fn2\">2</a> humans is here used to refer to any sapient creature</p></footer>")
+    assert(result == "<p>Greetings,<a href=\"#note:1\" name=\"rn:1\" rel=\"footnote\">1</a> humans<a href=\"#note:2\" name=\"rn:2\" rel=\"footnote\">2</a>!</p><footer><p><a class=\"fnote\" href=\"#rn:1\" name=\"note:1\">1</a> hohoho</p><p><a class=\"fnote\" href=\"#rn:2\" name=\"note:2\">2</a> humans is here used to refer to any sapient creature</p></footer>")
 
   }
 
@@ -300,7 +300,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.translate(text)
 
-    assert(result == "Greetings, humans<a href=\"#fn1\" name=\"rn1\" rel=\"footnote\">1</a>!")
+    assert(result == "Greetings, humans<a href=\"#note:1\" name=\"rn:1\" rel=\"footnote\">1</a>!")
   }
 
   it should "put alt text instead of footer if told to do so" in {
@@ -313,17 +313,5 @@ class HTMLTranslatorSpec extends FlatSpec {
     val result = new HTMLTranslator(footnote_as_title_text=true).translate(text)
 
     assert(result == "<p>Greetings, humans<a title=\"humans is here used to refer to any \\\"sapient\\\" creature\" rel=\"footnote\">1</a>!</p>")
-  }
-
-  it should "use <aside> if footnote_inline specified" in {
-    val text = Document(Seq(Paragraph(Seq(
-      StandardText("Greetings, humans"),
-      Footnote(Seq(StandardText("humans is here used to refer to any \"sapient\" creature"))),
-      StandardText("!")
-    ))))
-
-    val result = new HTMLTranslator(footnote_inline=true).translate(text)
-
-    assert(result == "<p>Greetings, humans<aside num=1>humans is here used to refer to any \"sapient\" creature</aside>!</p>")
   }
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -65,34 +65,16 @@ class HTMLTranslatorSpec extends FlatSpec {
     val result = translator.code(code)
 
     assert(result ==
-      """<pre><code>this  is code,
-        | yes</code></pre>""".stripMargin)
+      """<figure class="code"><code>this  is code,
+        | yes</code></figure>""".stripMargin)
   }
 
-  it should "optionally exclude the <pre> tag" in {
-    val code = Code(Map[String,String](), "this  is code,\n yes")
-
-    val result = new HTMLTranslator(wrap_code_with_pre=false).code(code)
-
-    assert(result ==
-      """<code>this  is code,
-        | yes</code>""".stripMargin)
-  }
-
-  it should "escape characters if not using the pre tag" in {
+  it should "escape characters" in {
     val code = Code(Map[String,String](), "x <= y")
 
-    val result = new HTMLTranslator(wrap_code_with_pre=false).code(code)
+    val result = translator.code(code)
 
-    assert(result == "<code>x &lt;= y</code>")
-  }
-
-  it should "not escape characters if using the pre tag" in {
-    val code = Code(Map[String,String](), "x <= y")
-
-    val result = new HTMLTranslator(wrap_code_with_pre=true).code(code)
-
-    assert(result == "<pre><code>x <= y</code></pre>")
+    assert(result == "<figure class=\"code\"><code>x &lt;= y</code></figure>")
   }
 
   it should "handle directives like a boss" in {
@@ -101,8 +83,8 @@ class HTMLTranslatorSpec extends FlatSpec {
     val result = translator.code(code)
 
     assert(result ==
-      """<pre><code lang="magic">square = lambda x: x ** 2
-        |square(2)</code></pre>""".stripMargin)
+      """<figure class="code"><code lang="magic">square = lambda x: x ** 2
+        |square(2)</code></figure>""".stripMargin)
   }
 
  "orderedList" should "translate an OrderedList" in {


### PR DESCRIPTION
HTMLTranslator now emits Footnote nodes, rather than ignoring them.

Includes two ways to emit footnotes: as part of a `<footer>` block emitted at the
end of parsing, and as the `title` attribute of the footnote link itself.

Also makes the `code` translator emit slightly more semantic `<figure>` blocks,
instead of optionally outputting `<pre>` tags.
