### PR TITLE
Change raw delimiter from = to |

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ name := """saxophone"""
 
 version := "1.2.0"
 
+organization := "com.haaksmash"
+
 lazy val root = (project in file("."))
 
 scalaVersion := "2.11.4"
@@ -11,3 +13,30 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test"
 
 mainClass in (Compile, run) := Some("com.haaksmash.saxophone.Application")
+
+publishMavenStyle := true
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+licenses := Seq("GPL v3" -> url("http://www.gnu.org/licenses/gpl-3.0.en.html"))
+
+homepage := Some(url("http://github.com/haaksmash/saxophone"))
+
+scmInfo := Some(ScmInfo(url("http://github.com/haaksmash/saxophone"), "scm:git@github.com:haaksmash/saxophone.git"))
+
+pomIncludeRepository := { x => false }
+
+pomExtra := (
+  <developers>
+    <developer>
+      <id>haaksmash</id>
+      <name>Haak Saxberg</name>
+      <url>http://haaksmash.com</url>
+    </developer>
+  </developers>)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
@@ -35,7 +35,7 @@ object InlineParsers extends RegexParsers {
   val STRUCKTHROUGH_START, STRUCKTHROUGH_END = '~'
   val UNDERLINE_START, UNDERLINE_END = '_'
   val MONOSPACE_START, MONOSPACE_END = '`'
-  val RAW_START, RAW_END = '='
+  val RAW_START, RAW_END = '|'
 
   val special_char_to_tracking_and_ending_char = Map(
     FOOTNOTE_START -> ("f", FOOTNOTE_END),

--- a/src/test/resources/article_example.sax
+++ b/src/test/resources/article_example.sax
@@ -19,7 +19,7 @@ and an unordered list:
 ## subheading here.
 
 _this text is underlined_, whereas ~this text is struck-through~. *this text is bolded*, whereas /this text is italicized/.
-and =this text is <raw/>= unlike <here>!
+and |this text is <raw/>| unlike <here>!
 
 In this paragraph, at long last, we come to the important part: `the code` (this last should appear monospaced).
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
@@ -73,8 +73,8 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "`hello`")
   }
 
-  "raw_text" should "match characters between =" in {
-    val input = "=`*RAW*`="
+  "raw_text" should "match characters between |" in {
+    val input = "|`*RAW*`|"
     val result = parsers.parseAll(parsers.raw_text, input).get
 
     assert(result.text == "`*RAW*`")
@@ -200,7 +200,7 @@ class InlineParsersSpec extends FlatSpec {
   }
 
   "elements" should "recognize raw marker strings" in {
-    val raw_result = parsers.parseAll(parsers.elements(), "and =this is **RAW**=")
+    val raw_result = parsers.parseAll(parsers.elements(), "and |this is **RAW**|")
     assert(!raw_result.isEmpty)
     assert(raw_result.get == Seq(StandardText("and "), RawText("this is **RAW**")))
   }


### PR DESCRIPTION
Turns out you often want to use the "=" inside of a raw block... but the parser
was looking for that character to end the raw segment. A recipe for disaster!

Instead, we will now use '|' as the boundaries of a raw segment, because it
seems much less likely that anyone will want to use pipe inside of a raw
section.
