### PR TITLE
ordered lists that render as unordered lists in HTML

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
@@ -30,6 +30,8 @@ import scala.util.parsing.input.{Position, Reader}
 class BlockParsers extends Parsers {
   type Elem = Line
 
+  val ORDERED_AS_UNORDERED_GLYPH = "-"
+
   /**
    * Matches & consumes a line of type T. Notably, it will __not__ match lines that
    * are subtypes of T.
@@ -80,6 +82,10 @@ class BlockParsers extends Parsers {
     else {
         var input = in
         var items = Seq[Seq[Node]]()
+        val present_unordered = if (input.first.isInstanceOf[OrderedLine]) {
+          val line = input.first.asInstanceOf[OrderedLine]
+          line.glyph == ORDERED_AS_UNORDERED_GLYPH
+        } else false
         while (input.first.isInstanceOf[OrderedLine]) {
           val leading_line = input.first.asInstanceOf[OrderedLine]
           // This is unfortunate; I'd like to use the `source` method on Reader[T], but that
@@ -107,7 +113,10 @@ class BlockParsers extends Parsers {
           input = input.rest.drop(sublines.length)
         }
 
-        val o = OrderedList(items)
+        val o = OrderedList(
+          items,
+          present_unordered
+        )
         Success(o, input.rest)
     }
   }

--- a/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
@@ -57,6 +57,7 @@ class LineParsers extends Parsers {
         case '*' => delegateParsing(line_parsers.unorderedListParser)(in)
         case '\n' => Success(EmptyLine(), in.rest)
         case n if '0' <= n && n <= '9' => delegateParsing(line_parsers.orderedListParser)(in)
+        case '-' => delegateParsing(line_parsers.orderedListParser)(in)
         case '>' => delegateParsing(line_parsers.quoteParser)(in)
         case '{' => delegateParsing(line_parsers.codeStart)(in)
         case '}' => delegateParsing(line_parsers.codeEnd)(in)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -34,7 +34,7 @@ trait StringLineParsers extends UtilParsers {
   val headingParser: Parser[HeadingLine] = s"${HEADING_GLYPH}+ ".r ~ rest ^^ {
     case glyphs ~ text =>
       // glyphs will end with a space that we want to throw away
-      HeadingLine(glyphs.slice(0, glyphs.length - 1), text)
+      HeadingLine(glyphs.trim, text)
   }
 
   val codeStart: Parser[CodeStartLine] = CODE_START ~> rest ^^ {
@@ -58,7 +58,8 @@ trait StringLineParsers extends UtilParsers {
   val quoteParser: Parser[QuoteLine] = s"$QUOTE_LINE\\s?".r ~ rest ^^ {case leader ~ text => QuoteLine(leader + text)}
 
   val unorderedListParser: Parser[UnorderedLine] = "\\*\\s?".r ~ rest ^^ {case leader ~ text => UnorderedLine(leader, text)}
-  val orderedListParser: Parser[OrderedLine] = "\\d+\\.\\s?".r ~ rest ^^ {case leader ~ text => OrderedLine(leader, text)}
+
+  val orderedListParser: Parser[OrderedLine] = ("\\d+\\.\\s?".r | "- ") ~ rest ^^ {case leader ~ text => OrderedLine(leader.trim, text)}
 
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -72,7 +72,7 @@ sealed abstract class ListNode(items: Traversable[Seq[Node]]) extends Node {
   def children = items.flatten
 }
 
-case class OrderedList(items: Seq[Seq[Node]]) extends ListNode(items) {
+case class OrderedList(items: Seq[Seq[Node]], present_unordered: Boolean = false) extends ListNode(items) {
   override val label = "ol"
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -51,7 +51,10 @@ class HTMLTranslator(
 
   def orderedList(node:OrderedList) = {
     val list_items = node.items.map(li => s"<li>${li.map(translate(_)).mkString}</li>") mkString ""
-    s"""<ol>$list_items</ol>"""
+    if (node.present_unordered)
+      s"""<ul>$list_items</ul>"""
+    else
+      s"""<ol>$list_items</ol>"""
   }
 
   def unorderedList(node:UnorderedList) = {

--- a/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
@@ -130,6 +130,14 @@ class BlockParsersSpec extends FlatSpec {
     assert(result.items == Seq(Seq(Paragraph(Seq(StandardText("list item 1")))), Seq(Paragraph(Seq(StandardText("list item 2"))))))
   }
 
+  it should "realize that it is meant to appear unordered" in {
+    val list = Seq(OrderedLine("-", "list item 1"), OrderedLine("-", "list item 2"))
+
+    val result = parsers.ordered_list_node(new LineReader(list)).get
+
+    assert(result.present_unordered == true)
+  }
+
   it should "recursively parse its leading line" in {
     val list = Seq(OrderedLine("1.", "list /item/ A"))
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -77,4 +77,12 @@ class StringLineParserSpec extends FlatSpec {
     }
   }
 
+  it should "match a '-' followed by a space" in {
+    val input = "- derptastic"
+    val ordered_line = parsers.parseAll(parsers.orderedListParser, input).get
+
+    assert(ordered_line.payload == "derptastic")
+    assert(ordered_line.glyph == "-")
+  }
+
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -101,6 +101,21 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == "<ol><li>Line One</li><li>Line Two</li><li>Line Three</li></ol>")
   }
 
+  it should "emit an 'unordered list' if commanded to do so" in {
+    val list = OrderedList(
+      Seq(
+        Seq(Paragraph(Seq(StandardText("Line One")))),
+        Seq(Paragraph(Seq(StandardText("Line Two")))),
+        Seq(Paragraph(Seq(StandardText("Line Three"))))
+      ),
+      present_unordered=true
+    )
+
+    val result = translator.orderedList(list)
+
+    assert(result == "<ul><li>Line One</li><li>Line Two</li><li>Line Three</li></ul>")
+  }
+
   "unorderedList" should "translate an UnorderedList" in {
     val list = UnorderedList(
       Set(


### PR DESCRIPTION
For non-traditionally-semantic reasons, you may want to have an ordered list appear as an unorderd list --- i.e., you want the dots but also a guarantee of the order in which your points are displayed.

This PR enables that meaning to be carried through; use a `-` instead of a `*` to demark your bullets and their order will be preserved, and the HTML translator will know to render them in a `<ul>`. The GithubMD translator will see them as a regular ordered list, however --- so this PR also encodes GithubMD as a second-class translator citizen, which I think is correct stance.
