### PR TITLE
Code listings can't end with a }

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here's how!
 add
 
 ```scala
-  libraryDependencies += "com.haaksmash" %% "saxophone" % "1.3.0"
+libraryDependencies += "com.haaksmash" %% "saxophone" % "1.3.0"
 ```
 to one of your project's sbt files.
 
@@ -45,10 +45,10 @@ to one of your project's sbt files.
 Pretty straightforward, choose the appropriate implementation of `BaseIntake` and send its output to the appropriate implementation of `BaseTranslator`, which will give you a String. Then, do what you want!
 
 ```scala
-  val input: Option[Document] = FileIntake(someFilename)
-  val output: Option[String] = input map {
-    HTMLTranslator.translate(_)
-  }
+val input: Option[Document] = FileIntake(someFilename)
+val output: Option[String] = input map {
+  HTMLTranslator.translate(_)
+}
 ```
 ### Syntax
 `saxophone` is a lot like Markdown, structurally; the syntax is what's different. All these examples use the HTML output, because that's pretty easy to understand.

--- a/README.sax
+++ b/README.sax
@@ -55,7 +55,7 @@ Here's how!
 add
 
 {{{lang:scala
-  libraryDependencies += "com.haaksmash" %% "saxophone" % "1.3.0"
+libraryDependencies += "com.haaksmash" %% "saxophone" % "1.3.0"
 }}}
 
 to one of your project's sbt files.
@@ -66,10 +66,10 @@ and send its output to the appropriate implementation of `BaseTranslator`,
 which will give you a String. Then, do what you want!
 
 {{{lang:scala
-  val input: Option[Document] = FileIntake(someFilename)
-  val output: Option[String] = input map {
-    HTMLTranslator.translate(_)
-  }
+val input: Option[Document] = FileIntake(someFilename)
+val output: Option[String] = input map {
+  HTMLTranslator.translate(_)
+}
 }}}
 
 ### Syntax

--- a/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
@@ -52,7 +52,7 @@ class LineParsers extends Parsers {
       val line = in.first
       val char = if (line.isEmpty) '\n' else line.charAt(0)
 
-      char match {
+      val maybe_result = char match {
         case '#' => delegateParsing(line_parsers.headingParser)(in)
         case '*' => delegateParsing(line_parsers.unorderedListParser)(in)
         case '\n' => Success(EmptyLine(), in.rest)
@@ -61,7 +61,15 @@ class LineParsers extends Parsers {
         case '>' => delegateParsing(line_parsers.quoteParser)(in)
         case '{' => delegateParsing(line_parsers.codeStart)(in)
         case '}' => delegateParsing(line_parsers.codeEnd)(in)
-        case _ => Success(TextLine(line), in.rest)
+        case _ => Failure("no matching start char", in)
+      }
+
+      // A line of text is *always* going to be a TextLine, if nothing else.
+      // Even if it starts with a suspcicious character and that doesn't pan
+      // out.
+      maybe_result match {
+        case Failure(_, _) => Success(TextLine(line), in.rest)
+        case x => x
       }
     }
   }

--- a/src/test/scala/com/haaksmash/saxophone/parsers/LineParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/LineParsersSpec.scala
@@ -1,0 +1,18 @@
+package com.haaksmash.saxophone.parsers
+
+import com.haaksmash.saxophone.primitives.TextLine
+import com.haaksmash.saxophone.readers.StringLineReader
+import org.scalatest.FlatSpec
+
+class LineParsersSpec extends FlatSpec {
+  object parsers extends LineParsers
+
+  "line_token" should "make a textline out of '{' and '}'" in {
+
+    val input = "{\nredleather\n}"
+
+    val result = parsers.lines(new StringLineReader(input)).get
+
+    assert(result == Seq(TextLine("{"), TextLine("redleather"), TextLine("}")))
+  }
+}

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -84,5 +84,4 @@ class StringLineParserSpec extends FlatSpec {
     assert(ordered_line.payload == "derptastic")
     assert(ordered_line.glyph == "-")
   }
-
 }


### PR DESCRIPTION
See the following minimal example:

```
hello!

{{{
this is
a good day
to bracket
}
}}}

indeed it is!
```

sax will only output

```
hello!


```

't'ain't right
