### PR TITLE
Make an actual pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ val output:Try[String] = saxophone.Pipeline
   .to(new FileEmitter("output file")) // optional!
   .process()
 ```
+It doesn't matter what order you call `on`/`via`/`to`/`from`; they each return a brand-new `Pipeline`. `Pipeline` even tries to choose sensible defaults for you if you process a bit more eagerly:
+
+```scala
+saxophone.Pipeline
+  // on() is the only required builder method
+  .on("source")
+  .process()
+
+
+// equivalent to the more-verbose
+saxophone.Pipeline
+  .on("source").
+  .from(new StringIntake)
+  .via(new HTMLTranslator)
+  .process()
+```
 ### Syntax
 `saxophone` is a lot like Markdown, structurally; the syntax is what's different. All these examples use the HTML output, because that's pretty easy to understand.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ libraryDependencies += "com.haaksmash" %% "saxophone" % "1.4.0"
 to one of your project's sbt files.
 
 ### Usage
-Pretty straightforward, choose the appropriate implementation of `BaseIntake` and send its output to the appropriate implementation of `BaseTranslator`, which will give you a String. Then, do what you want!
+Pretty straightforward; choose the appropriate implementation of `BaseIntake` and `BaseTranslator`, specify a source string, and let the `Pipeline` `process` everything for you!
 
 ```scala
-val input: Option[Document] = FileIntake(someFilename)
-val output: Option[String] = input map {
-  HTMLTranslator.translate(_)
-}
+val output:Try[String] = saxophone.Pipeline
+  .from(new FileIntake)
+  // this string will have different meanings depending on your chosen intake;
+  // in this case, it will be interpreted as a file path.
+  .on("filename")
+  .via(new HTMLTranslator)
+  .to(new FileEmitter("output file")) // optional!
+  .process()
 ```
 ### Syntax
 `saxophone` is a lot like Markdown, structurally; the syntax is what's different. All these examples use the HTML output, because that's pretty easy to understand.

--- a/README.sax
+++ b/README.sax
@@ -61,15 +61,19 @@ libraryDependencies += "com.haaksmash" %% "saxophone" % "1.4.0"
 to one of your project's sbt files.
 
 ### Usage
-Pretty straightforward, choose the appropriate implementation of `BaseIntake`
-and send its output to the appropriate implementation of `BaseTranslator`,
-which will give you a String. Then, do what you want!
+Pretty straightforward; choose the appropriate implementation of `BaseIntake`
+and `BaseTranslator`, specify a source string, and let the `Pipeline` `process`
+everything for you!
 
 {{{lang:scala
-val input: Option[Document] = FileIntake(someFilename)
-val output: Option[String] = input map {
-  HTMLTranslator.translate(_)
-}
+val output:Try[String] = saxophone.Pipeline
+  .from(new FileIntake)
+  // this string will have different meanings depending on your chosen intake;
+  // in this case, it will be interpreted as a file path.
+  .on("filename")
+  .via(new HTMLTranslator)
+  .to(new FileEmitter("output file")) // optional!
+  .process()
 }}}
 
 ### Syntax

--- a/README.sax
+++ b/README.sax
@@ -76,6 +76,24 @@ val output:Try[String] = saxophone.Pipeline
   .process()
 }}}
 
+It doesn't matter what order you call `on`\/`via`\/`to`\/`from`; they each return a brand-new
+`Pipeline`. `Pipeline` even tries to choose sensible defaults for you if you process
+a bit more eagerly:
+
+{{{lang:scala
+saxophone.Pipeline
+  // on() is the only required builder method
+  .on("source")
+  .process()
+
+// equivalent to the more-verbose
+saxophone.Pipeline
+  .on("source").
+  .from(new StringIntake)
+  .via(new HTMLTranslator)
+  .process()
+}}}
+
 ### Syntax
 `saxophone` is a lot like Markdown, structurally; the syntax is what's
 different. All these examples use the HTML output, because that's pretty easy

--- a/src/main/scala/com/haaksmash/saxophone/Application.scala
+++ b/src/main/scala/com/haaksmash/saxophone/Application.scala
@@ -81,7 +81,7 @@ object Application {
         if (args.contains ("-d"))
           ConsoleEmitter.emit(s)
       case Failure(ex) =>
-        System.err.println("Could not process input as a saxophone document")
+        System.err.println(ex.getMessage)
         System.exit(1)
     }
 

--- a/src/main/scala/com/haaksmash/saxophone/Application.scala
+++ b/src/main/scala/com/haaksmash/saxophone/Application.scala
@@ -20,7 +20,7 @@ package com.haaksmash.saxophone
 
 import com.haaksmash.saxophone.emitters.{ConsoleEmitter, FileEmitter}
 import com.haaksmash.saxophone.intakes.FileIntake
-import com.haaksmash.saxophone.translators.{SaxophoneTreeStringTranslator, GithubMDTranslator, HTMLTranslator}
+import com.haaksmash.saxophone.translators.{GithubMDTranslator, HTMLTranslator, SaxophoneTreeStringTranslator}
 
 import scala.util.{Failure, Success}
 
@@ -65,8 +65,8 @@ object Application {
       }
     }
 
-   val emitter = if (args.contains ("-o")) {
-      val output_filename = args (args.indexOf ("-o") + 1)
+    val emitter = if (args.contains("-o")) {
+      val output_filename = args(args.indexOf("-o") + 1)
       FileEmitter(output_filename)
     } else {
       ConsoleEmitter
@@ -74,11 +74,15 @@ object Application {
 
     val saxophone_filename = args(args.length - 1)
 
-    val pipe = Pipeline.via(translator).from(new FileIntake).on(saxophone_filename).to(emitter)
+    val pipe = Pipeline
+      .on(saxophone_filename)
+      .from(new FileIntake)
+      .via(translator)
+      .to(emitter)
 
     pipe.process() match {
       case Success(s) =>
-        if (args.contains ("-d"))
+        if (args.contains("-d"))
           ConsoleEmitter.emit(s)
       case Failure(ex) =>
         System.err.println(ex.getMessage)

--- a/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
+++ b/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
@@ -46,6 +46,7 @@ class Pipeline(
   emitter:Option[BaseEmitter],
   input: Option[String]
 ) extends PipelineDefinition {
+
   override def from[T <: BaseIntake](intake: T): Pipeline = new Pipeline(
     Some(intake),
     translator,

--- a/src/main/scala/com/haaksmash/saxophone/PipelineDefinition.scala
+++ b/src/main/scala/com/haaksmash/saxophone/PipelineDefinition.scala
@@ -1,0 +1,149 @@
+/*
+ * saxophone - a markup processing program
+ * Copyright (C) 2015  Haak Saxberg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.haaksmash.saxophone
+
+import com.haaksmash.saxophone.emitters.BaseEmitter
+import com.haaksmash.saxophone.intakes.{StringIntake, BaseIntake}
+import com.haaksmash.saxophone.parsers.{BlockParsers, LineParsers}
+import com.haaksmash.saxophone.readers.{LineReader, StringLineReader}
+import com.haaksmash.saxophone.translators.{HTMLTranslator, BaseTranslator}
+
+import scala.util.{Try, Success, Failure}
+
+
+trait PipelineDefinition {
+  def intake: Option[BaseIntake] = None
+  def translator: Option[BaseTranslator] = None
+  def emitter: Option[BaseEmitter] = None
+  def input: Option[String] = None
+
+  def from[T <: BaseIntake](intake: T): PipelineDefinition
+  def via[T <: BaseTranslator](translator: T): PipelineDefinition
+  def to[T <: BaseEmitter](emitter: T): PipelineDefinition
+  def on(input:String): PipelineDefinition
+}
+
+
+class Pipeline(
+  intake:Option[BaseIntake],
+  translator:Option[BaseTranslator],
+  emitter:Option[BaseEmitter],
+  input: Option[String]
+) extends PipelineDefinition {
+  override def from[T <: BaseIntake](intake: T): Pipeline = new Pipeline(
+    Some(intake),
+    translator,
+    emitter,
+    input
+  )
+
+  override def to[T <: BaseEmitter](emitter: T): Pipeline = new Pipeline(
+    intake,
+    translator,
+    Some(emitter),
+    input
+  )
+
+  override def via[T <: BaseTranslator](translator: T): Pipeline = new Pipeline(
+    intake,
+    Some(translator),
+    emitter,
+    input
+  )
+
+  override def on(input: String) = new Pipeline(
+    intake,
+    translator,
+    emitter,
+    Some(input)
+  )
+
+  def process(): Try[String] = {
+    if (input.isEmpty)
+      return Failure(new RuntimeException("can't process without input"))
+
+    val intake_result = intake match {
+        case Some(i) => i.intake(input.get)
+        case None => StringIntake(input.get)
+      }
+
+    if (intake_result.isFailure)
+      return intake_result
+
+    val translate_result = intake_result
+      .map (in =>
+        (new LineParsers).lines(new StringLineReader(in)))
+      .map(lines =>
+        (new BlockParsers).blocks(new LineReader(lines.get)))
+      .map ( doc =>
+        translator match {
+          case Some(t) => t.translate(doc.get)
+          case None => HTMLTranslator.translate(doc.get)
+        }
+      )
+
+    if (translate_result.isFailure)
+      return translate_result
+
+    val emit_result = translate_result.map( in =>
+      emitter match {
+        case Some(e) =>
+          e.emit(in)
+          in
+        case None => in
+      }
+    )
+
+    return emit_result match {
+      case Success(r) => Success(r)
+      case Failure(_) => Failure(new RuntimeException("could not emit result"))
+    }
+  }
+}
+
+object Pipeline extends PipelineDefinition {
+  override def from[T <: BaseIntake](intake: T): Pipeline = new Pipeline(
+    Some(intake),
+    None,
+    None,
+    None
+  )
+
+  override def to[T <: BaseEmitter](emitter: T): Pipeline = new Pipeline(
+    None,
+    None,
+    Some(emitter),
+    None
+  )
+
+  override def via[T <: BaseTranslator](translator: T): Pipeline = new Pipeline(
+    None,
+    Some(translator),
+    None,
+    None
+  )
+
+  override def on(input: String) = new Pipeline(
+    None,
+    None,
+    None,
+    Some(input)
+  )
+}
+

--- a/src/main/scala/com/haaksmash/saxophone/emitters/FileEmitter.scala
+++ b/src/main/scala/com/haaksmash/saxophone/emitters/FileEmitter.scala
@@ -20,7 +20,7 @@ package com.haaksmash.saxophone.emitters
 
 import java.io.{BufferedWriter, File, FileWriter}
 
-class FileEmitter(val filename:String) extends BaseEmitter {
+class FileEmitter(val filename: String) extends BaseEmitter {
   override def emit(contents: String): Unit = {
     val file = new File(filename)
     val writer = new BufferedWriter(new FileWriter(file))
@@ -30,5 +30,5 @@ class FileEmitter(val filename:String) extends BaseEmitter {
 }
 
 object FileEmitter {
-  def apply(filename:String) = new FileEmitter(filename)
+  def apply(filename: String) = new FileEmitter(filename)
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/BaseIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/BaseIntake.scala
@@ -18,10 +18,8 @@
 
 package com.haaksmash.saxophone.intakes
 
-import com.haaksmash.saxophone.primitives.Document
-
 import scala.util.Try
 
 trait BaseIntake {
-  def intake(input:String): Try[String]
+  def intake(input: String): Try[String]
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/BaseIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/BaseIntake.scala
@@ -20,7 +20,8 @@ package com.haaksmash.saxophone.intakes
 
 import com.haaksmash.saxophone.primitives.Document
 
+import scala.util.Try
+
 trait BaseIntake {
-  type IntakeType
-  def intake(input:IntakeType): Option[Document]
+  def intake(input:String): Try[String]
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/ConsoleIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/ConsoleIntake.scala
@@ -18,11 +18,11 @@
 
 package com.haaksmash.saxophone.intakes
 
-import com.haaksmash.saxophone.primitives.Document
+import scala.util.Try
 
 
 object ConsoleIntake {
-  def apply(): Option[Document] = {
+  def apply(): Try[String] = {
     val lines = io.Source.stdin.getLines().mkString("\n")
     StringIntake(lines)
   }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/FileIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/FileIntake.scala
@@ -23,9 +23,9 @@ import java.io.File
 import scala.util.Try
 
 class FileIntake extends BaseIntake {
-  def intake(filename:String): Try[String] = intake(new File(filename))
+  def intake(filename: String): Try[String] = intake(new File(filename))
 
-  def intake(file:File): Try[String] = {
+  def intake(file: File): Try[String] = {
 
     val article_source = scala.io.Source.fromFile(file)
     val the_article = article_source.mkString
@@ -40,7 +40,7 @@ object FileIntake {
     (new FileIntake).intake(filename)
   }
 
-  def apply(file:File): Try[String] = {
+  def apply(file: File): Try[String] = {
     (new FileIntake).intake(file)
   }
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/FileIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/FileIntake.scala
@@ -20,14 +20,14 @@ package com.haaksmash.saxophone.intakes
 
 import java.io.File
 
-import com.haaksmash.saxophone.primitives.Document
+import scala.util.Try
 
 class FileIntake extends BaseIntake {
-  type IntakeType = File
+  def intake(filename:String): Try[String] = intake(new File(filename))
 
-  def intake(filename:IntakeType): Option[Document] = {
+  def intake(file:File): Try[String] = {
 
-    val article_source = scala.io.Source.fromFile(filename)
+    val article_source = scala.io.Source.fromFile(file)
     val the_article = article_source.mkString
     article_source.close()
 
@@ -36,11 +36,11 @@ class FileIntake extends BaseIntake {
 }
 
 object FileIntake {
-  def apply(filename: String) = {
-    (new FileIntake).intake(new File(filename))
+  def apply(filename: String): Try[String] = {
+    (new FileIntake).intake(filename)
   }
 
-  def apply(file:File) = {
+  def apply(file:File): Try[String] = {
     (new FileIntake).intake(file)
   }
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/StringIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/StringIntake.scala
@@ -22,38 +22,14 @@ import com.haaksmash.saxophone.parsers.{LineParsers, BlockParsers}
 import com.haaksmash.saxophone.primitives.Document
 import com.haaksmash.saxophone.readers.{LineReader, StringLineReader}
 
-class StringIntake(
-  val string_tokenizer: LineParsers,
-  val block_parser: BlockParsers) extends BaseIntake {
+import scala.util.Try
 
-  type IntakeType = String
-
-  def intake(input: IntakeType): Option[Document] = {
-    /*val lines = string_tokenizer.eval(input)
-    (lines map {
-      l => block_parser.blocks(new LineReader(l))
-    }).get.get
-    */
-    val lines = string_tokenizer.lines(new StringLineReader(input))
-    if (lines.isEmpty) {
-      return None
-    }
-
-    val blocks = block_parser.blocks(new LineReader(lines.get))
-
-    if (blocks.isEmpty) {
-      return None
-    }
-
-    Some(blocks.get)
-  }
+class StringIntake extends BaseIntake {
+  override def intake(input: String): Try[String] = Try(input)
 }
 
 object StringIntake {
-  def apply(input:String): Option[Document] = {
-    new StringIntake(
-      string_tokenizer = new LineParsers,
-      block_parser = new BlockParsers
-    ).intake(input)
+  def apply(input:String): Try[String] = {
+    new StringIntake().intake(input)
   }
 }

--- a/src/main/scala/com/haaksmash/saxophone/intakes/StringIntake.scala
+++ b/src/main/scala/com/haaksmash/saxophone/intakes/StringIntake.scala
@@ -18,10 +18,6 @@
 
 package com.haaksmash.saxophone.intakes
 
-import com.haaksmash.saxophone.parsers.{LineParsers, BlockParsers}
-import com.haaksmash.saxophone.primitives.Document
-import com.haaksmash.saxophone.readers.{LineReader, StringLineReader}
-
 import scala.util.Try
 
 class StringIntake extends BaseIntake {
@@ -29,7 +25,7 @@ class StringIntake extends BaseIntake {
 }
 
 object StringIntake {
-  def apply(input:String): Try[String] = {
+  def apply(input: String): Try[String] = {
     new StringIntake().intake(input)
   }
 }

--- a/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
@@ -48,7 +48,7 @@ object InlineParsers extends RegexParsers {
     RAW_START -> ("r", RAW_END)
   )
 
-  def aChar = Parser{ in =>
+  def aChar = Parser { in =>
     if (in.atEnd) {
       Failure("End of input reached.", in)
     } else {
@@ -56,7 +56,7 @@ object InlineParsers extends RegexParsers {
     }
   }
 
-  def standardText(special: Set[Char]): Parser[StandardText] = Parser{ in =>
+  def standardText(special: Set[Char]): Parser[StandardText] = Parser { in =>
     if (in.atEnd)
       Failure("End of input reached.", in)
     else {
@@ -65,12 +65,12 @@ object InlineParsers extends RegexParsers {
       val end = source.length()
       val result = new StringBuilder()
 
-      while (pos<end && !special.contains(source.charAt(pos))) {
+      while (pos < end && !special.contains(source.charAt(pos))) {
         val c = source.charAt(pos)
         if (
-          c == '\\' &&
-          pos + 1 < end &&
-          special_char_to_tracking_and_ending_char.contains(source.charAt(pos + 1))
+          c == '\\'
+          && pos + 1 < end
+          && special_char_to_tracking_and_ending_char.contains(source.charAt(pos + 1))
         ) {
           result.append(source.charAt(pos + 1))
           pos += 2

--- a/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
@@ -18,7 +18,7 @@
 
 package com.haaksmash.saxophone.parsers
 
-import com.haaksmash.saxophone.primitives.{TextLine, EmptyLine, Line}
+import com.haaksmash.saxophone.primitives.{EmptyLine, Line, TextLine}
 import com.haaksmash.saxophone.readers.StringLineReader
 
 import scala.util.parsing.combinator._
@@ -28,24 +28,25 @@ import scala.util.parsing.combinator._
  */
 class LineParsers extends Parsers {
   type Elem = String
+
   object line_parsers extends StringLineParsers
 
   /**
    * Stupid hack so this tokenizer can use [[com.haaksmash.saxophone.parsers.StringLineParsers]]
    * parsers as if they were its own.
    */
-  private def delegateParsing[T](parser:line_parsers.Parser[T]):Parser[T] = Parser {in =>
+  private def delegateParsing[T](parser: line_parsers.Parser[T]): Parser[T] = Parser { in =>
     if (in.atEnd)
-      Failure("End of input in "+ parser, in)
+      Failure("End of input in " + parser, in)
     else {
       line_parsers.parseAll(parser, in.first) match {
         case line_parsers.Success(t, _) => Success(t.asInstanceOf[T], in.rest)
-        case n:line_parsers.NoSuccess => Failure(n.msg, in)
+        case n: line_parsers.NoSuccess => Failure(n.msg, in)
       }
     }
   }
 
-  val line_token:Parser[Line] = Parser {in =>
+  val line_token: Parser[Line] = Parser { in =>
     if (in.atEnd)
       Failure("End of input in line_token", in)
     else {
@@ -76,7 +77,7 @@ class LineParsers extends Parsers {
 
   val lines: Parser[Seq[Line]] = line_token.*
 
-  def eval(input:String) = {
+  def eval(input: String) = {
     lines(new StringLineReader(input)) match {
       case Success(result, _) => Some(result)
       case Failure(msg, _) =>

--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -55,11 +55,11 @@ trait StringLineParsers extends UtilParsers {
 
   val codeEnd: Parser[CodeEndLine] = CODE_END ^^^ {CodeEndLine()}
 
-  val quoteParser: Parser[QuoteLine] = s"$QUOTE_LINE\\s?".r ~ rest ^^ {case leader ~ text => QuoteLine(leader + text)}
+  val quoteParser: Parser[QuoteLine] = s"$QUOTE_LINE\\s".r ~ rest ^^ {case leader ~ text => QuoteLine(leader + text)}
 
-  val unorderedListParser: Parser[UnorderedLine] = "\\*\\s?".r ~ rest ^^ {case leader ~ text => UnorderedLine(leader, text)}
+  val unorderedListParser: Parser[UnorderedLine] = "\\*\\s".r ~ rest ^^ {case leader ~ text => UnorderedLine(leader, text)}
 
-  val orderedListParser: Parser[OrderedLine] = ("\\d+\\.\\s?".r | "- ") ~ rest ^^ {case leader ~ text => OrderedLine(leader.trim, text)}
+  val orderedListParser: Parser[OrderedLine] = ("\\d+\\.\\s".r | "- ") ~ rest ^^ {case leader ~ text => OrderedLine(leader.trim, text)}
 
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
@@ -25,7 +25,7 @@ trait UtilParsers extends RegexParsers {
    * Matches everything in the input string up to the end, including the empty string.
    * Returns the matched string.
    */
-  val rest:Parser[String] = Parser {in =>
+  val rest: Parser[String] = Parser { in =>
     if (in.atEnd)
       Success("", in)
     else {

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Lines.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Lines.scala
@@ -20,9 +20,11 @@ package com.haaksmash.saxophone.primitives
 
 sealed abstract trait Line {
   def text: String
+
   def payload = text
 }
-case class HeadingLine(prefix:String, text:String) extends Line {
+
+case class HeadingLine(prefix: String, text: String) extends Line {
   override val payload: String = {
     text.trim.reverse.dropWhile(_ == '#').reverse
   }
@@ -31,31 +33,37 @@ case class HeadingLine(prefix:String, text:String) extends Line {
 
   override def toString = "HeadingLine(" + headerLevel + ", " + payload + ")"
 }
-case class TextLine(text:String) extends Line
 
-case class EmptyLine(text:String="") extends Line
+case class TextLine(text: String) extends Line
 
-case class CodeStartLine(directives:Map[String, String], text:String="") extends Line
+case class EmptyLine(text: String = "") extends Line
 
-case class CodeEndLine(text:String="") extends Line
+case class CodeStartLine(directives: Map[String, String], text: String = "") extends Line
 
-case class QuoteLine(text:String) extends Line {
+case class CodeEndLine(text: String = "") extends Line
+
+case class QuoteLine(text: String) extends Line {
   override val payload: String = text.trim.dropWhile(_ == '>').trim
+
   override def toString = "QuoteLine(" + payload + ")"
 }
 
 
 sealed abstract trait ListLine extends Line {
   def glyph: String
+
   def raw_text: String
+
   override val payload: String = raw_text.trim
+
   override def text = glyph + " " + payload
+
   override def toString = getClass.getName + "(" + text + ")"
 }
 
-case class OrderedLine(glyph: String, raw_text:String) extends ListLine
+case class OrderedLine(glyph: String, raw_text: String) extends ListLine
 
-case class UnorderedLine(glyph: String, raw_text:String) extends ListLine
+case class UnorderedLine(glyph: String, raw_text: String) extends ListLine
 
 object EOF extends Line {
   val text = "EOF"

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -20,8 +20,11 @@ package com.haaksmash.saxophone.primitives
 
 sealed abstract class Node {
   def children: Traversable[Node]
+
   val label = "node"
+
   def label_display = s"$label"
+
   override def toString = s"<$label_display>${children.mkString("")}</$label>"
 }
 
@@ -31,6 +34,7 @@ case class Document(children: Seq[Node]) extends Node {
 
 case class Heading(level: Int, children: Seq[Node]) extends Node {
   override val label = s"H"
+
   override def label_display = s"$label level=$level"
 }
 
@@ -43,14 +47,19 @@ case class ForcedNewline() extends Node {
   override val toString = "<br/>"
 }
 
-case class Code(directives: Map[String, String], contents:String) extends Node {
+case class Code(directives: Map[String, String], contents: String) extends Node {
   val children = Seq.empty
   override val label = "code"
-  override def toString = s"""<$label ${(directives map {case (k, v) => s"""$k="$v""""}).mkString(" ")}>$contents</$label>"""
+
+  override def toString = s"""<$label ${
+    (directives map { case (k, v) => s"""$k="$v"""" })
+      .mkString(" ")
+  }>$contents</$label>"""
 }
 
 case class Quote(children: Seq[Node], source: Option[Seq[InlineNode]]) extends Node {
   override val label = "quote"
+
   override def label_display = {
     source match {
       case Some(s) =>
@@ -76,7 +85,7 @@ case class OrderedList(items: Seq[Seq[Node]], present_unordered: Boolean = false
   override val label = "ol"
 }
 
-case class UnorderedList(items: Set[Seq[Node]]) extends ListNode(items){
+case class UnorderedList(items: Set[Seq[Node]]) extends ListNode(items) {
   override val label = "ul"
 }
 
@@ -88,48 +97,53 @@ case class Footnote(children: Seq[InlineNode]) extends InlineNode {
   override val label = "foot"
 }
 
-case class RawText(text:String) extends InlineNode {
+case class RawText(text: String) extends InlineNode {
   val children = Seq.empty[Node]
+
   override def toString = "<raw>" + text + "</raw>"
 }
 
 trait TransformedText extends InlineNode {
   val children = Seq.empty[Node]
-  def text:String
+
+  def text: String
+
   override def toString = s"<$label_display>$text</$label>"
 }
 
-case class StandardText(text:String) extends TransformedText {
+case class StandardText(text: String) extends TransformedText {
   override def toString = "<text>" + text + "</text>"
 }
 
-case class EmphasizedText(text:String) extends TransformedText {
+case class EmphasizedText(text: String) extends TransformedText {
   override val label = "em"
 }
 
-case class WeightedText(weight:Int, text:String) extends TransformedText {
+case class WeightedText(weight: Int, text: String) extends TransformedText {
   override val label = "strong"
 }
 
-case class UnderlinedText(text:String) extends TransformedText {
+case class UnderlinedText(text: String) extends TransformedText {
   override val label = "u"
 }
 
-case class MonospaceText(text:String) extends TransformedText {
+case class MonospaceText(text: String) extends TransformedText {
   override val label = "mono"
 }
 
-case class StruckthroughText(text:String) extends TransformedText {
+case class StruckthroughText(text: String) extends TransformedText {
   override val label = "strike"
 }
 
 
 case class Link(override val children: Seq[InlineNode], to: LinkTarget) extends InlineNode {
   override val label = "a"
+
   override def label_display = s"$label target=$to"
 }
 
 case class LinkTarget(target: String) extends InlineNode {
   val children = Seq.empty
+
   override def toString = target
 }

--- a/src/main/scala/com/haaksmash/saxophone/readers/LineReader.scala
+++ b/src/main/scala/com/haaksmash/saxophone/readers/LineReader.scala
@@ -22,10 +22,10 @@ import com.haaksmash.saxophone.primitives.{EOF, Line}
 
 import scala.util.parsing.input.{Position, Reader}
 
-class LineReader private (val lines: Seq[Line], val lookup: Option[Boolean], val linecount: Int)
+class LineReader private(val lines: Seq[Line], val lookup: Option[Boolean], val linecount: Int)
   extends Reader[Line] {
 
-  def this(ls:Seq[Line]) = this(ls, None, 1)
+  def this(ls: Seq[Line]) = this(ls, None, 1)
 
   override def first: Line = if (lines.isEmpty) EOF else lines.head
 
@@ -33,7 +33,9 @@ class LineReader private (val lines: Seq[Line], val lookup: Option[Boolean], val
 
   override def pos: Position = new Position {
     def line = linecount
+
     override def column: Int = 1
+
     protected def lineContents = first.text
   }
 

--- a/src/main/scala/com/haaksmash/saxophone/readers/StringLineReader.scala
+++ b/src/main/scala/com/haaksmash/saxophone/readers/StringLineReader.scala
@@ -20,12 +20,13 @@ package com.haaksmash.saxophone.readers
 
 import scala.util.parsing.input.{Position, Reader}
 
-class StringLineReader private (val lines: Seq[String], val lineCount: Int) extends Reader[String] {
+class StringLineReader private(val lines: Seq[String], val lineCount: Int) extends Reader[String] {
 
   private val eofline = "EOF"
 
-  def this(ls:Seq[String]) = this(ls, 1)
-  def this(ls:String) = this(ls.split('\n'))
+  def this(ls: Seq[String]) = this(ls, 1)
+
+  def this(ls: String) = this(ls.split('\n'))
 
   override def first: String = if (lines.isEmpty) eofline else lines.head
 
@@ -33,7 +34,9 @@ class StringLineReader private (val lines: Seq[String], val lineCount: Int) exte
 
   override def pos: Position = new Position {
     def line = lineCount
+
     override def column: Int = 1
+
     override protected def lineContents: String = first
   }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -22,6 +22,10 @@ import com.haaksmash.saxophone.primitives._
 
 
 trait BaseTranslator {
+  def translate(node: Node): String
+}
+
+trait NodeTranslator extends BaseTranslator {
 
 
   /**

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -34,31 +34,45 @@ trait NodeTranslator extends BaseTranslator {
    * @param node
    * @return String
    */
-  def node(node:Node): String = node.toString
+  def node(node: Node): String = node.toString
 
-  def heading(node:Heading): String
-  def paragraph(node:Paragraph): String
-  def code(node:Code): String
-  def quote(node:Quote): String
-  def orderedList(node:OrderedList) : String
-  def unorderedList(node:UnorderedList): String
-  def footnote(node:Footnote): String
-  def link(node:Link): String
+  def heading(node: Heading): String
+
+  def paragraph(node: Paragraph): String
+
+  def code(node: Code): String
+
+  def quote(node: Quote): String
+
+  def orderedList(node: OrderedList): String
+
+  def unorderedList(node: UnorderedList): String
+
+  def footnote(node: Footnote): String
+
+  def link(node: Link): String
 
   /*
    * Inline nodes; i.e., nodes that don't have children, but only capture
    * meta data about their contents.
    */
-  def emphasizedText(node:EmphasizedText): String
-  def forcedNewLine(node:ForcedNewline): String
-  def standardText(node:StandardText): String
-  def struckthroughText(node:StruckthroughText): String
-  def underlinedText(node:UnderlinedText): String
-  def weightedText(node:WeightedText): String
-  def monospacedText(node:MonospaceText): String
-  def rawText(node:RawText): String
+  def emphasizedText(node: EmphasizedText): String
 
-  def node_to_translator(n:Node) = n match {
+  def forcedNewLine(node: ForcedNewline): String
+
+  def standardText(node: StandardText): String
+
+  def struckthroughText(node: StruckthroughText): String
+
+  def underlinedText(node: UnderlinedText): String
+
+  def weightedText(node: WeightedText): String
+
+  def monospacedText(node: MonospaceText): String
+
+  def rawText(node: RawText): String
+
+  def node_to_translator(n: Node) = n match {
     case n: StandardText => standardText(n)
     case n: Link => link(n)
     case n: EmphasizedText => emphasizedText(n)
@@ -81,12 +95,14 @@ trait NodeTranslator extends BaseTranslator {
 
     val output = node.children match {
       case Seq() => Traversable(translateSingle(node))
-      case children => children map {node_to_translator(_)}
+      case children => children map {
+        node_to_translator(_)
+      }
     }
     output.mkString
   }
 
-  private def translateSingle(node:Node): String = {
+  private def translateSingle(node: Node): String = {
     node_to_translator(node)
   }
 }

--- a/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
@@ -20,7 +20,7 @@ package com.haaksmash.saxophone.translators
 
 import com.haaksmash.saxophone.primitives._
 
-class GithubMDTranslator extends BaseTranslator {
+class GithubMDTranslator extends NodeTranslator {
   override def heading(node: Heading): String = s"${"#" * node.level} ${translate(node)}\n"
 
   override def footnote(node: Footnote): String = ""

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable.ListMap
 class HTMLTranslator(
   allow_raw_strings:Boolean=true,
   footnote_as_title_text:Boolean=false
-) extends BaseTranslator {
+) extends NodeTranslator {
 
   var footnotes = Seq[String]()
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -24,8 +24,8 @@ import scala.collection.immutable.ListMap
 
 
 class HTMLTranslator(
-  allow_raw_strings:Boolean=true,
-  footnote_as_title_text:Boolean=false
+  allow_raw_strings: Boolean=true,
+  footnote_as_title_text: Boolean=false
 ) extends NodeTranslator {
 
   var footnotes = Seq[String]()

--- a/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
@@ -21,7 +21,7 @@ package com.haaksmash.saxophone.translators
 import com.haaksmash.saxophone.primitives._
 
 
-class SaxophoneTreeStringTranslator extends BaseTranslator {
+class SaxophoneTreeStringTranslator extends NodeTranslator {
 
   override def heading(node: Heading): String = ???
 

--- a/src/test/scala/com/haaksmash/saxophone/PipelineSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/PipelineSpec.scala
@@ -22,27 +22,33 @@ class PipelineSpec extends FlatSpec {
 
   "Pipeline.from" should "not modify itself but return new Pipelines" in {
     val pipe = new Pipeline(None, None, None, None)
-    val new_pipe = pipe.from(new BaseIntake {
-      override def intake(input: String): Try[String] = ???
-    })
+    val new_pipe = pipe.from(
+      new BaseIntake {
+        override def intake(input: String): Try[String] = ???
+      }
+    )
 
     assert(pipe != new_pipe)
   }
 
   "Pipeline.via" should "not modify itself but return new Pipelines" in {
     val pipe = new Pipeline(None, None, None, None)
-    val new_pipe = pipe.via(new BaseTranslator {
-      override def translate(node: Node): String = ???
-    })
+    val new_pipe = pipe.via(
+      new BaseTranslator {
+        override def translate(node: Node): String = ???
+      }
+    )
 
     assert(pipe != new_pipe)
   }
 
   "Pipeline.to" should "not modify itself but return new Pipelines" in {
     val pipe = new Pipeline(None, None, None, None)
-    val new_pipe = pipe.to(new BaseEmitter {
-      override def emit(contents: String): Unit = ???
-    })
+    val new_pipe = pipe.to(
+      new BaseEmitter {
+        override def emit(contents: String): Unit = ???
+      }
+    )
 
     assert(pipe != new_pipe)
   }
@@ -57,23 +63,29 @@ class PipelineSpec extends FlatSpec {
   "Pipeline.process" should "run an input through all the stages of the pipe" in {
     var operations = Seq.empty[String]
     val pipe = new Pipeline(
-      Some(new BaseIntake {
-        override def intake(input: String): Try[String] = Try {
-          operations = operations :+ "intake"
-          input
+      Some(
+        new BaseIntake {
+          override def intake(input: String): Try[String] = Try {
+            operations = operations :+ "intake"
+            input
+          }
         }
-      }),
-      Some(new BaseTranslator {
-        override def translate(node: Node): String = {
-          operations = operations :+ "translate"
-          "translation"
+      ),
+      Some(
+        new BaseTranslator {
+          override def translate(node: Node): String = {
+            operations = operations :+ "translate"
+            "translation"
+          }
         }
-      }),
-      Some(new BaseEmitter {
-        override def emit(contents: String): Unit = {
-          operations = operations :+ "emit"
+      ),
+      Some(
+        new BaseEmitter {
+          override def emit(contents: String): Unit = {
+            operations = operations :+ "emit"
+          }
         }
-      }),
+      ),
       Some("input")
     )
 

--- a/src/test/scala/com/haaksmash/saxophone/PipelineSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/PipelineSpec.scala
@@ -1,0 +1,86 @@
+package com.haaksmash.saxophone
+
+import com.haaksmash.saxophone.emitters.BaseEmitter
+import com.haaksmash.saxophone.intakes.BaseIntake
+import com.haaksmash.saxophone.primitives.Node
+import com.haaksmash.saxophone.translators.BaseTranslator
+import org.scalatest.FlatSpec
+
+import scala.util.Try
+
+class PipelineSpec extends FlatSpec {
+
+  "Pipeline" should "process to Failure when no input" in {
+    val pipe = new Pipeline(None, None, None, None).process()
+    assert(pipe.isFailure)
+  }
+
+  it should "have defaults aside from input" in {
+    val pipe = new Pipeline(None, None, None, Some("lalala")).process()
+    assert(pipe.isSuccess)
+  }
+
+  "Pipeline.from" should "not modify itself but return new Pipelines" in {
+    val pipe = new Pipeline(None, None, None, None)
+    val new_pipe = pipe.from(new BaseIntake {
+      override def intake(input: String): Try[String] = ???
+    })
+
+    assert(pipe != new_pipe)
+  }
+
+  "Pipeline.via" should "not modify itself but return new Pipelines" in {
+    val pipe = new Pipeline(None, None, None, None)
+    val new_pipe = pipe.via(new BaseTranslator {
+      override def translate(node: Node): String = ???
+    })
+
+    assert(pipe != new_pipe)
+  }
+
+  "Pipeline.to" should "not modify itself but return new Pipelines" in {
+    val pipe = new Pipeline(None, None, None, None)
+    val new_pipe = pipe.to(new BaseEmitter {
+      override def emit(contents: String): Unit = ???
+    })
+
+    assert(pipe != new_pipe)
+  }
+
+  "Pipeline.on" should "not modify itself but return new Pipelines" in {
+    val pipe = new Pipeline(None, None, None, None)
+    val new_pipe = pipe.on("lalala")
+
+    assert(pipe != new_pipe)
+  }
+
+  "Pipeline.process" should "run an input through all the stages of the pipe" in {
+    var operations = Seq.empty[String]
+    val pipe = new Pipeline(
+      Some(new BaseIntake {
+        override def intake(input: String): Try[String] = Try {
+          operations = operations :+ "intake"
+          input
+        }
+      }),
+      Some(new BaseTranslator {
+        override def translate(node: Node): String = {
+          operations = operations :+ "translate"
+          "translation"
+        }
+      }),
+      Some(new BaseEmitter {
+        override def emit(contents: String): Unit = {
+          operations = operations :+ "emit"
+        }
+      }),
+      Some("input")
+    )
+
+    val output = pipe.process()
+
+    assert(output.isSuccess)
+    assert(operations == Seq("intake", "translate", "emit"))
+  }
+
+}

--- a/src/test/scala/com/haaksmash/saxophone/intakes/FileIntakeSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/intakes/FileIntakeSpec.scala
@@ -27,17 +27,15 @@ class FileIntakeSpec extends FlatSpec {
   val article_filepath = getClass.getResource("/article_example.sax").getPath
 
   "FileIntake" should "successfully evaluate a .sax file by path" in {
-    val document = FileIntake(article_filepath)
+    val output = FileIntake(article_filepath)
 
-    assert(document.isDefined)
-    assert(document.get.children.length > 1)
+    assert(output.isSuccess)
   }
 
   it should "evaluate a .sax file directly" in {
     val article = new File(article_filepath)
-    val document = FileIntake(article)
+    val output = FileIntake(article)
 
-    assert(document.isDefined)
-    assert(document.get.children.length > 1)
+    assert(output.isSuccess)
   }
 }

--- a/src/test/scala/com/haaksmash/saxophone/intakes/StringIntakeSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/intakes/StringIntakeSpec.scala
@@ -22,11 +22,11 @@ import org.scalatest._
 
 class StringIntakeSpec extends FlatSpec {
   "StringIntake" should "successfully evaluate a string" in {
-    val document = StringIntake("# Title\na paragraph\n\nanother paragraph /with emphasis/ and *weight*")
+    val input = "# Title\na paragraph\n\nanother paragraph /with emphasis/ and *weight*"
+    val output = StringIntake(input)
 
-    assert(document.isDefined)
-    assert(document.get.children.length == 3)
-    assert(document.get.children.last.children.toSeq.length == 4)
+    assert(output.isSuccess)
+    assert(output.get == input)
   }
 
 }

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -61,11 +61,25 @@ class StringLineParserSpec extends FlatSpec {
     assert(quote_line.payload == "a quote goes here")
   }
 
+  it should "require a following space" in {
+    val input = ">>>not quote"
+    val the_line = parsers.parseAll(parsers.quoteParser, input)
+
+    assert(the_line.isEmpty)
+  }
+
   "unordered_line" should "match *" in {
     val input = "* unordered line!"
     val unordered_line = parsers.parseAll(parsers.unorderedListParser, input).get
 
     assert(unordered_line.payload == "unordered line!")
+  }
+
+  it should "require a following space" in {
+    val input = "*not unordered*"
+    val the_line = parsers.parseAll(parsers.unorderedListParser, input)
+
+    assert(the_line.isEmpty)
   }
 
   "ordered_line" should "match any number followed by a period" in {
@@ -83,5 +97,12 @@ class StringLineParserSpec extends FlatSpec {
 
     assert(ordered_line.payload == "derptastic")
     assert(ordered_line.glyph == "-")
+  }
+
+  it should "require a following space" in {
+    val input = "1.not ordered*"
+    val the_line = parsers.parseAll(parsers.orderedListParser, input)
+
+    assert(the_line.isEmpty)
   }
 }


### PR DESCRIPTION
The various implementors of `BaseIntake` know way too much, in particular `StringIntake`. There should be a shepherding class that knows about intakes, translators, and emitters, and coordinates their activities.

Ideal code use:

``` scala
val output: Try[String] = Pipeline
  .from(FileIntake)
  .via(HTMLTranslator)
  .to(StringEmitter)(someFilename)
```

obviously provide a public constructor as well to skip the verbose-y builder methods
