### PR TITLE
Allow metadata to be attached to inline nodes

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
@@ -109,7 +109,7 @@ object InlineParsers extends RegexParsers {
     case text ~ meta => WeightedText(1, text.mkString, meta.getOrElse(Map()))
   }
 
-  val underlined_text: Parser[MarkedText] = (UNDERLINE_START ~> ((not(UNDERLINE_END) ~> aChar).+) <~ UNDERLINE_END) ~ metadata.? ^^ {
+  val marked_text: Parser[MarkedText] = (UNDERLINE_START ~> ((not(UNDERLINE_END) ~> aChar).+) <~ UNDERLINE_END) ~ metadata.? ^^ {
     case chars ~ meta => MarkedText(chars.mkString, meta.getOrElse(Map()))
   }
 
@@ -170,7 +170,7 @@ object InlineParsers extends RegexParsers {
           if (visited contains special_char_to_tracking_and_ending_char(UNDERLINE_START)._1)
             Failure("can't nest underline", in)
           else
-            underlined_text(in)
+            marked_text(in)
         case MONOSPACE_START =>
           if (visited contains special_char_to_tracking_and_ending_char(MONOSPACE_START)._1)
             Failure("can't nest monospace", in)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
@@ -88,29 +88,37 @@ object InlineParsers extends RegexParsers {
     }
   }
 
+  val metadata: Parser[Map[String, String]] = "[" ~> ((not("]") ~> aChar).+) <~ "]" ^^ {
+    case metas =>
+      metas.mkString.split('|')
+        .map(metapair => metapair.split(':'))
+        .map(l => l(0) -> l(1))
+        .toMap
+  }
+
   val raw_text: Parser[RawText] = RAW_START ~> ((not(RAW_END) ~> aChar).+) <~ RAW_END ^^ {
     case chars => RawText(chars.mkString)
   }
 
-  val emphasized_text: Parser[EmphasizedText] = EMPHASIZED_START ~> ((not(EMPHASIZED_END) ~> aChar).+) <~ EMPHASIZED_END ^^ {
-    case chars => EmphasizedText(chars.mkString)
+  val emphasized_text: Parser[EmphasizedText] = (EMPHASIZED_START ~> ((not(EMPHASIZED_END) ~> aChar).+) <~ EMPHASIZED_END) ~ metadata.? ^^ {
+    case chars ~ meta => EmphasizedText(chars.mkString, meta.getOrElse(Map()))
   }
 
-  val weighted_text: Parser[WeightedText] = WEIGHTED_START ~> ((not(WEIGHTED_END) ~> aChar).+) <~ WEIGHTED_END^^ {
+  val weighted_text: Parser[WeightedText] = (WEIGHTED_START ~> ((not(WEIGHTED_END) ~> aChar).+) <~ WEIGHTED_END) ~ metadata.? ^^ {
     // For now, only support a single level of added-weight
-    case text => WeightedText(1, text.mkString)
+    case text ~ meta => WeightedText(1, text.mkString, meta.getOrElse(Map()))
   }
 
-  val underlined_text: Parser[UnderlinedText] = UNDERLINE_START ~> ((not(UNDERLINE_END) ~> aChar).+) <~ UNDERLINE_END ^^ {
-    case chars => UnderlinedText(chars.mkString)
+  val underlined_text: Parser[MarkedText] = (UNDERLINE_START ~> ((not(UNDERLINE_END) ~> aChar).+) <~ UNDERLINE_END) ~ metadata.? ^^ {
+    case chars ~ meta => MarkedText(chars.mkString, meta.getOrElse(Map()))
   }
 
-  val struckthrough_text: Parser[StruckthroughText] = STRUCKTHROUGH_START ~> ((not(STRUCKTHROUGH_END) ~> aChar).+) <~ STRUCKTHROUGH_END ^^ {
-    case chars => StruckthroughText(chars.mkString)
+  val struckthrough_text: Parser[StruckthroughText] = (STRUCKTHROUGH_START ~> ((not(STRUCKTHROUGH_END) ~> aChar).+) <~ STRUCKTHROUGH_END) ~ metadata.? ^^ {
+    case chars ~ meta => StruckthroughText(chars.mkString, meta.getOrElse(Map()))
   }
 
-  val monospaced_text: Parser[MonospaceText] = MONOSPACE_START ~> standardText(Set(MONOSPACE_END)) <~ MONOSPACE_END ^^ {
-    case text => MonospaceText(text.text)
+  val monospaced_text: Parser[MonospaceText] = (MONOSPACE_START ~> standardText(Set(MONOSPACE_END)) <~ MONOSPACE_END) ~ metadata.? ^^ {
+    case text ~ meta => MonospaceText(text.text, meta.getOrElse(Map()))
   }
 
   val link_text: Parser[Link] = (LINK_START ~> ((not(LINK_END)~> aChar).+) <~ LINK_END) ~

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -90,8 +90,9 @@ case class UnorderedList(items: Set[Seq[Node]]) extends ListNode(items) {
 }
 
 
-trait InlineNode extends Node
-
+trait InlineNode extends Node {
+  def meta = Map[String, String]()
+}
 
 case class Footnote(children: Seq[InlineNode]) extends InlineNode {
   override val label = "foot"
@@ -115,23 +116,23 @@ case class StandardText(text: String) extends TransformedText {
   override def toString = "<text>" + text + "</text>"
 }
 
-case class EmphasizedText(text: String) extends TransformedText {
+case class EmphasizedText(text: String, override val meta: Map[String, String]) extends TransformedText {
   override val label = "em"
 }
 
-case class WeightedText(weight: Int, text: String) extends TransformedText {
+case class WeightedText(weight: Int, text: String, override val meta: Map[String, String]) extends TransformedText {
   override val label = "strong"
 }
 
-case class UnderlinedText(text: String) extends TransformedText {
+case class MarkedText(text: String, override val meta: Map[String, String]) extends TransformedText {
   override val label = "u"
 }
 
-case class MonospaceText(text: String) extends TransformedText {
+case class MonospaceText(text: String, override val meta: Map[String, String]) extends TransformedText {
   override val label = "mono"
 }
 
-case class StruckthroughText(text: String) extends TransformedText {
+case class StruckthroughText(text: String, override val meta: Map[String, String]) extends TransformedText {
   override val label = "strike"
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -64,7 +64,7 @@ trait NodeTranslator extends BaseTranslator {
 
   def struckthroughText(node: StruckthroughText): String
 
-  def underlinedText(node: UnderlinedText): String
+  def markedText(node: MarkedText): String
 
   def weightedText(node: WeightedText): String
 
@@ -83,7 +83,7 @@ trait NodeTranslator extends BaseTranslator {
     case n: OrderedList => orderedList(n)
     case n: Code => code(n)
     case n: StruckthroughText => struckthroughText(n)
-    case n: UnderlinedText => underlinedText(n)
+    case n: MarkedText => markedText(n)
     case n: MonospaceText => monospacedText(n)
     case n: RawText => rawText(n)
     case n: Quote => quote(n)

--- a/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
@@ -51,7 +51,7 @@ class GithubMDTranslator extends NodeTranslator {
 
   override def weightedText(node: WeightedText): String = s"**${node.text}**"
 
-  override def underlinedText(node: UnderlinedText): String = s"${node.text}"
+  override def markedText(node: MarkedText): String = s"${node.text}"
 
   override def struckthroughText(node: StruckthroughText): String = s"~~${node.text}~~"
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -79,13 +79,15 @@ class HTMLTranslator(
    * metadata about their contents.
    */
   def link(node:Link) = s"""<a href="${node.to}">${translate(node)}</a>"""
-  def emphasizedText(node:EmphasizedText) = s"<em>${escapeTextForHTML(node.text)}</em>"
+  def emphasizedText(node:EmphasizedText) = s"<em${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</em>"
   def forcedNewLine(node:ForcedNewline) = "<br/>"
   def standardText(node:StandardText) = escapeTextForHTML(node.text)
-  def struckthroughText(node:StruckthroughText) = s"<s>${escapeTextForHTML(node.text)}</s>"
-  def underlinedText(node:UnderlinedText) = s"""<mark>${escapeTextForHTML(node.text)}</mark>"""
-  def weightedText(node:WeightedText) = s"<strong>${escapeTextForHTML(node.text)}</strong>"
-  def monospacedText(node:MonospaceText) = s"<code>${escapeTextForHTML(node.text)}</code>"
+  def struckthroughText(node:StruckthroughText) = s"<s${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</s>"
+  def markedText(node:MarkedText) = s"""<mark${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</mark>"""
+  def weightedText(node:WeightedText) = s"<strong${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</strong>"
+  def monospacedText(node:MonospaceText) = {
+    s"""<code${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</code>"""
+  }
   def rawText(node: RawText) = if (allow_raw_strings) node.text else escapeTextForHTML(node.text)
 
 
@@ -121,6 +123,14 @@ class HTMLTranslator(
       new_text = new_text.replaceAll(char, chars_to_escape_sequence(char))
     }
     new_text
+  }
+
+  private def convertMetaToHTMLAttrs(meta:Map[String, String]): String = {
+    val meta_string = meta.map{case (k,v) => s"""$k="$v""""}.mkString(" ")
+    if (!meta_string.isEmpty)
+      " " + meta_string
+    else
+      ""
   }
 
 }

--- a/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
@@ -45,7 +45,7 @@ class SaxophoneTreeStringTranslator extends NodeTranslator {
 
   override def weightedText(node: WeightedText): String = ???
 
-  override def underlinedText(node: UnderlinedText): String = ???
+  override def markedText(node: MarkedText): String = ???
 
   override def struckthroughText(node: StruckthroughText): String = ???
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
@@ -102,7 +102,7 @@ class BlockParsersSpec extends FlatSpec {
     val result = parsers.unordered_list_node(new LineReader(list)).get
 
     assert(result.items == Set(
-      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item"), StandardText(" A"))))
+      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
     ))
   }
 
@@ -144,7 +144,7 @@ class BlockParsersSpec extends FlatSpec {
     val result = parsers.ordered_list_node(new LineReader(list)).get
 
     assert(result.items == Seq(
-      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item"), StandardText(" A"))))
+      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
     ))
   }
 
@@ -196,10 +196,10 @@ class BlockParsersSpec extends FlatSpec {
     val result = parsers.paragraph(new LineReader(text)).get
 
     assert(result.children == Seq(
-      MonospaceText("mono"), StandardText(" "),
-      WeightedText(1, "weight"), StandardText(" "),
-      EmphasizedText("emph"), StandardText(" "),
-      UnderlinedText("mark")
+      MonospaceText("mono", Map()), StandardText(" "),
+      WeightedText(1, "weight", Map()), StandardText(" "),
+      EmphasizedText("emph", Map()), StandardText(" "),
+      MarkedText("mark", Map())
     ))
   }
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/BlockParsersSpec.scala
@@ -23,6 +23,7 @@ import com.haaksmash.saxophone.readers.LineReader
 import org.scalatest._
 
 class BlockParsersSpec extends FlatSpec {
+
   object parsers extends BlockParsers
 
   "quote_node" must "recognize a QuoteLine" in {
@@ -64,7 +65,13 @@ class BlockParsersSpec extends FlatSpec {
   }
 
   "code_node" must "grab stuff between CodeStart/CodeEndLine, join them by newlines" in {
-    val codez = Seq(CodeStartLine(Map()), TextLine("line one"), TextLine("/line two/"), UnorderedLine("*", "a line a line"), CodeEndLine())
+    val codez = Seq(
+      CodeStartLine(Map()),
+      TextLine("line one"),
+      TextLine("/line two/"),
+      UnorderedLine("*", "a line a line"),
+      CodeEndLine()
+    )
 
     val result = parsers.code_node(new LineReader(codez)).get
 
@@ -93,7 +100,12 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.unordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Set(Seq(Paragraph(Seq(StandardText("list item A")))), Seq(Paragraph(Seq(StandardText("list item B"))))))
+    assert(
+      result.items == Set(
+        Seq(Paragraph(Seq(StandardText("list item A")))),
+        Seq(Paragraph(Seq(StandardText("list item B"))))
+      )
+    )
   }
 
   it should "recursively parse its leading line" in {
@@ -101,9 +113,11 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.unordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Set(
-      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
-    ))
+    assert(
+      result.items == Set(
+        Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
+      )
+    )
   }
 
   it should "scoop TextLines into the previous UnorderedLine" in {
@@ -111,15 +125,29 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.unordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Set(Seq(Paragraph(Seq(StandardText("list item A item A continued")))), Seq(Paragraph(Seq(StandardText("list item B"))))))
+    assert(
+      result.items == Set(
+        Seq(Paragraph(Seq(StandardText("list item A item A continued")))),
+        Seq(Paragraph(Seq(StandardText("list item B"))))
+      )
+    )
   }
 
   it should "not scoop nonTextLines into the previous UnorderedLine" in {
-    val list = Seq(UnorderedLine("*", "list item A"), UnorderedLine("*", "list item B"), QuoteLine("item B NOT continued"))
+    val list = Seq(
+      UnorderedLine("*", "list item A"),
+      UnorderedLine("*", "list item B"),
+      QuoteLine("item B NOT continued")
+    )
 
     val result = parsers.unordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Set(Seq(Paragraph(Seq(StandardText("list item A")))), Seq(Paragraph(Seq(StandardText("list item B"))))))
+    assert(
+      result.items == Set(
+        Seq(Paragraph(Seq(StandardText("list item A")))),
+        Seq(Paragraph(Seq(StandardText("list item B"))))
+      )
+    )
   }
 
   "ordered_list_node" must "recognize OrderedLines" in {
@@ -127,7 +155,12 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.ordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Seq(Seq(Paragraph(Seq(StandardText("list item 1")))), Seq(Paragraph(Seq(StandardText("list item 2"))))))
+    assert(
+      result.items == Seq(
+        Seq(Paragraph(Seq(StandardText("list item 1")))),
+        Seq(Paragraph(Seq(StandardText("list item 2"))))
+      )
+    )
   }
 
   it should "realize that it is meant to appear unordered" in {
@@ -143,9 +176,11 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.ordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Seq(
-      Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
-    ))
+    assert(
+      result.items == Seq(
+        Seq(Paragraph(Seq(StandardText("list "), EmphasizedText("item", Map()), StandardText(" A"))))
+      )
+    )
   }
 
   it should "scoop TextLines into the previous OrderedLine" in {
@@ -153,15 +188,29 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.ordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Seq(Seq(Paragraph(Seq(StandardText("list item 1 item 1 continued")))), Seq(Paragraph(Seq(StandardText("list item 2"))))))
+    assert(
+      result.items == Seq(
+        Seq(Paragraph(Seq(StandardText("list item 1 item 1 continued")))),
+        Seq(Paragraph(Seq(StandardText("list item 2"))))
+      )
+    )
   }
 
   it should "not scoop nonTextLines into the previous OrderedLine" in {
-    val list = Seq(OrderedLine("1.", "list item 1"), OrderedLine("2.", "list item 2"), QuoteLine("item 2 NOT continued"))
+    val list = Seq(
+      OrderedLine("1.", "list item 1"),
+      OrderedLine("2.", "list item 2"),
+      QuoteLine("item 2 NOT continued")
+    )
 
     val result = parsers.ordered_list_node(new LineReader(list)).get
 
-    assert(result.items == Seq(Seq(Paragraph(Seq(StandardText("list item 1")))), Seq(Paragraph(Seq(StandardText("list item 2"))))))
+    assert(
+      result.items == Seq(
+        Seq(Paragraph(Seq(StandardText("list item 1")))),
+        Seq(Paragraph(Seq(StandardText("list item 2"))))
+      )
+    )
   }
 
   "paragraph" must "eat as many TextLines as it wants" in {
@@ -195,12 +244,14 @@ class BlockParsersSpec extends FlatSpec {
 
     val result = parsers.paragraph(new LineReader(text)).get
 
-    assert(result.children == Seq(
-      MonospaceText("mono", Map()), StandardText(" "),
-      WeightedText(1, "weight", Map()), StandardText(" "),
-      EmphasizedText("emph", Map()), StandardText(" "),
-      MarkedText("mark", Map())
-    ))
+    assert(
+      result.children == Seq(
+        MonospaceText("mono", Map()), StandardText(" "),
+        WeightedText(1, "weight", Map()), StandardText(" "),
+        EmphasizedText("emph", Map()), StandardText(" "),
+        MarkedText("mark", Map())
+      )
+    )
   }
 
   "header_node" must "recognize HeaderLines" in {

--- a/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
@@ -139,6 +139,14 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "hello")
   }
 
+  it should "support metadata" in {
+    val input = "~hello~[class:red]"
+    val result = parsers.parseAll(parsers.struckthrough_text, input).get
+
+    assert(result.text == "hello")
+    assert(result.meta == Map("class" -> "red"))
+  }
+
   "monospaced_text" should "match characters between `" in {
     val input = "`hello`"
     val result = parsers.parseAll(parsers.monospaced_text, input).get

--- a/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
@@ -101,7 +101,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
       Set(
         Seq(Paragraph(Seq(StandardText("Line One")))),
         // ensures recursive translation
-        Seq(Paragraph(Seq(EmphasizedText("Line Two")))),
+        Seq(Paragraph(Seq(EmphasizedText("Line Two", Map())))),
         Seq(Paragraph(Seq(StandardText("Line Three"))))
       )
     )
@@ -124,7 +124,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
   }
 
   it should "recursively translate" in {
-    val link = Link(Seq(EmphasizedText("the link!")), LinkTarget("the target"))
+    val link = Link(Seq(EmphasizedText("the link!", Map())), LinkTarget("the target"))
 
     val result = translator.link(link)
 
@@ -132,7 +132,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
   }
 
   "emphasizedText" should "translate an EmphasizedText" in {
-    val text = EmphasizedText("IMPORTANT!")
+    val text = EmphasizedText("IMPORTANT!", Map())
 
     val result = translator.emphasizedText(text)
 
@@ -140,7 +140,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
   }
 
   "weightedText" should "translate a WeightedText" in {
-    val text = WeightedText(1, "HEAVY!")
+    val text = WeightedText(1, "HEAVY!", Map())
 
     val result = translator.weightedText(text)
 
@@ -156,17 +156,17 @@ class GithubMDTranslatorSpec extends FlatSpec {
   }
 
   "struckthroughText" should "translate a StruckthroughText" in {
-    val text = StruckthroughText("mah texticles!")
+    val text = StruckthroughText("mah texticles!", Map())
 
     val result = translator.struckthroughText(text)
 
     assert(result == "~~mah texticles!~~")
   }
 
-  "underlinedText" should "transparently fail" in {
-    val text = UnderlinedText("defective link")
+  "markedText" should "transparently fail" in {
+    val text = MarkedText("defective link", Map())
 
-    val result = translator.underlinedText(text)
+    val result = translator.markedText(text)
 
     assert(result == "defective link")
   }
@@ -187,7 +187,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
   }
 
   "monospacedText" should "translate a MonospaceText" in {
-    val text = MonospaceText("some_codeling")
+    val text = MonospaceText("some_codeling", Map())
 
     val result = translator.monospacedText(text)
 

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -121,7 +121,7 @@ class HTMLTranslatorSpec extends FlatSpec {
       Set(
         Seq(Paragraph(Seq(StandardText("Line One")))),
         // ensures recursive translation
-        Seq(Paragraph(Seq(EmphasizedText("Line Two")))),
+        Seq(Paragraph(Seq(EmphasizedText("Line Two", Map())))),
         Seq(Paragraph(Seq(StandardText("Line Three"))))
       )
     )
@@ -146,7 +146,7 @@ class HTMLTranslatorSpec extends FlatSpec {
   }
 
   it should "recursively translate" in {
-    val link = Link(Seq(EmphasizedText("the link!")), LinkTarget("the target"))
+    val link = Link(Seq(EmphasizedText("the link!", Map())), LinkTarget("the target"))
 
     val result = translator.link(link)
 
@@ -154,16 +154,24 @@ class HTMLTranslatorSpec extends FlatSpec {
  }
 
   "emphasizedText" should "translate an EmphasizedText" in {
-    val text = EmphasizedText("IMPORTANT!")
+    val text = EmphasizedText("IMPORTANT!", Map())
 
     val result = translator.emphasizedText(text)
 
     assert(result == "<em>IMPORTANT!</em>")
   }
 
+  it should "honor metadata" in {
+    val text = EmphasizedText("IMPORTANT!", Map("class" -> "red"))
+
+    val result = translator.emphasizedText(text)
+
+    assert(result == "<em class=\"red\">IMPORTANT!</em>")
+  }
+
   it should "escape its text" in {
 
-    val text = EmphasizedText("<look> &<a tag>")
+    val text = EmphasizedText("<look> &<a tag>", Map())
     val result = translator.translate(text)
 
     assert(result.contains("&gt;"))
@@ -172,7 +180,7 @@ class HTMLTranslatorSpec extends FlatSpec {
   }
 
   "weightedText" should "translate a WeightedText" in {
-    val text = WeightedText(1, "HEAVY!")
+    val text = WeightedText(1, "HEAVY!", Map())
 
     val result = translator.weightedText(text)
 
@@ -181,12 +189,20 @@ class HTMLTranslatorSpec extends FlatSpec {
 
   it should "escape its text" in {
 
-    val text = WeightedText(1, "<look> &<a tag>")
+    val text = WeightedText(1, "<look> &<a tag>", Map())
     val result = translator.translate(text)
 
     assert(result.contains("&gt;"))
     assert(result.contains("&lt;"))
     assert(result.contains("&amp;"))
+  }
+
+  it should "honor metadata" in {
+    val text = WeightedText(1, "HEAVY!", Map("class" -> "red"))
+
+    val result = translator.weightedText(text)
+
+    assert(result == "<strong class=\"red\">HEAVY!</strong>")
   }
 
   "standardText" should "translate a StandardText" in {
@@ -208,19 +224,27 @@ class HTMLTranslatorSpec extends FlatSpec {
   }
 
   "struckthroughText" should "translate a StruckthroughText" in {
-    val text = StruckthroughText("mah texticles!")
+    val text = StruckthroughText("mah texticles!", Map())
 
     val result = translator.struckthroughText(text)
 
     assert(result == "<s>mah texticles!</s>")
   }
 
-  "underlinedText" should "translate an UnderlinedText" in {
-    val text = UnderlinedText("defective link")
+  "markedText" should "translate an MarkedText" in {
+    val text = MarkedText("defective link", Map())
 
-    val result = translator.underlinedText(text)
+    val result = translator.markedText(text)
 
     assert(result == "<mark>defective link</mark>")
+  }
+
+  it should "honor metadata" in {
+    val text = MarkedText("defective link", Map("class" -> "red"))
+
+    val result = translator.markedText(text)
+
+    assert(result == "<mark class=\"red\">defective link</mark>")
   }
 
   "rawText" should "translate a RawText" in {
@@ -239,7 +263,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
   it should "escape its text" in {
 
-    val text = UnderlinedText("<look> &<a tag>")
+    val text = MarkedText("<look> &<a tag>", Map())
     val result = translator.translate(text)
 
     assert(result.contains("&gt;"))
@@ -256,7 +280,7 @@ class HTMLTranslatorSpec extends FlatSpec {
   }
 
   "monospacedText" should "translate a MonospaceText" in {
-    val text = MonospaceText("some_codeling")
+    val text = MonospaceText("some_codeling", Map())
 
     val result = translator.monospacedText(text)
 
@@ -265,12 +289,20 @@ class HTMLTranslatorSpec extends FlatSpec {
 
   it should "escape its text" in {
 
-    val text = MonospaceText("<look> &<a tag>")
+    val text = MonospaceText("<look> &<a tag>", Map())
     val result = translator.translate(text)
 
     assert(result.contains("&gt;"))
     assert(result.contains("&lt;"))
     assert(result.contains("&amp;"))
+  }
+
+  it should "honor metadata" in {
+    val text = MonospaceText("defective link", Map("class" -> "red"))
+
+    val result = translator.monospacedText(text)
+
+    assert(result == "<code class=\"red\">defective link</code>")
   }
 
   "footnote" should "translate footnotes" in {


### PR DESCRIPTION
Syntax would be something like `/emphasis/[class:warning]`, and the translators can do with that info what they will; `HTMLTranslator` would probably produce `<em class="warning">emphasis</em>`, for example.

Downside: overloads the `[]` construction further, which is already used for both link text and quote sources, although I can see the argument made that the quote source is exactly the same purpose as this.
