### PR TITLE
support embedding things somehow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/haaksmash/saxophone.svg?branch=master)](https://travis-ci.org/haaksmash/saxophone)
-
 # `saxophone`
 Ugh, what? ANOTHER preprocessor language? YES.
 

--- a/README.sax
+++ b/README.sax
@@ -1,4 +1,4 @@
-|[![Build Status](https://travis-ci.org/haaksmash/saxophone.svg?branch=master)](https://travis-ci.org/haaksmash/saxophone)|
+::image https://travis-ci.org/haaksmash/saxophone.svg?branch=master::[link:https://travis-ci.org/haaksmash/saxophone|alt:Build Status|]
 # `saxophone`
 Ugh, what? ANOTHER preprocessor language? YES.
 

--- a/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
+++ b/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
@@ -99,17 +99,15 @@ class Pipeline(
           (new LineParsers).lines(new StringLineReader(in))
       )
       .map(
-        lines => {
-          println(lines)
-          (new BlockParsers).blocks(new LineReader(lines.get))}
+        lines =>
+          (new BlockParsers).blocks(new LineReader(lines.get))
       )
       .map(
-        doc => {
-          println(doc)
+        doc =>
           translator match {
             case Some(t) => t.translate(doc.get)
             case None => HTMLTranslator.translate(doc.get)
-          }}
+          }
       )
 
     if (translate_result.isFailure)

--- a/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
+++ b/src/main/scala/com/haaksmash/saxophone/Pipeline.scala
@@ -99,15 +99,17 @@ class Pipeline(
           (new LineParsers).lines(new StringLineReader(in))
       )
       .map(
-        lines =>
-          (new BlockParsers).blocks(new LineReader(lines.get))
+        lines => {
+          println(lines)
+          (new BlockParsers).blocks(new LineReader(lines.get))}
       )
       .map(
-        doc =>
+        doc => {
+          println(doc)
           translator match {
             case Some(t) => t.translate(doc.get)
             case None => HTMLTranslator.translate(doc.get)
-          }
+          }}
       )
 
     if (translate_result.isFailure)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
@@ -24,7 +24,7 @@ import com.haaksmash.saxophone.readers.LineReader
 import scala.util.parsing.combinator.Parsers
 
 /**
- * The block parsers translate com.haaksmash.saxophone.Line -> com.haaksmash.saxophone.Node
+ * The block parsers translate [[com.haaksmash.saxophone.primitives.Line]] to [[com.haaksmash.saxophone.primitives.Node]]
  */
 class BlockParsers extends Parsers {
   type Elem = Line
@@ -62,18 +62,18 @@ class BlockParsers extends Parsers {
       Success(in.first, in.rest)
   }
 
-  val header_node: Parser[Heading] = line(classOf[HeadingLine]) ^^ {
+  lazy val header_node: Parser[Heading] = line(classOf[HeadingLine]) ^^ {
     case h => Heading(h.headerLevel, Seq(StandardText(h.payload)))
   }
 
-  val paragraph: Parser[Paragraph] = line(classOf[TextLine]).+ ^^ {
+  lazy val paragraph: Parser[Paragraph] = line(classOf[TextLine]).+ ^^ {
     case text_lines =>
       val text = text_lines.map(_.payload).mkString(" ").trim
       val parsed_text = InlineParsers.parseAll(InlineParsers.elements(Set.empty), text).get
       Paragraph(parsed_text)
   }
 
-  val ordered_list_node: Parser[OrderedList] = Parser { in =>
+  lazy val ordered_list_node: Parser[OrderedList] = Parser { in =>
     if (in.atEnd)
       Failure("End of input", in)
     else if (!in.first.isInstanceOf[OrderedLine])
@@ -81,10 +81,11 @@ class BlockParsers extends Parsers {
     else {
       var input = in
       var items = Seq[Seq[Node]]()
-      val present_unordered = if (input.first.isInstanceOf[OrderedLine]) {
-        val line = input.first.asInstanceOf[OrderedLine]
-        line.glyph == ORDERED_AS_UNORDERED_GLYPH
-      } else false
+      val present_unordered = input.first match {
+        case line: OrderedLine =>
+          line.glyph == ORDERED_AS_UNORDERED_GLYPH
+        case _ => false
+      }
       while (input.first.isInstanceOf[OrderedLine]) {
         val leading_line = input.first.asInstanceOf[OrderedLine]
         // This is unfortunate; I'd like to use the `source` method on Reader[T], but that
@@ -102,7 +103,7 @@ class BlockParsers extends Parsers {
 
         items = items ++ Seq(
         {
-          if (sublines.length > 0)
+          if (sublines.nonEmpty)
             Seq(
               nodes(new LineReader(TextLine(leading_line.payload) +: sublines)).get
             )
@@ -122,7 +123,7 @@ class BlockParsers extends Parsers {
     }
   }
 
-  val unordered_list_node: Parser[UnorderedList] = Parser { in =>
+  lazy val unordered_list_node: Parser[UnorderedList] = Parser { in =>
     if (in.atEnd)
       Failure("End of input", in)
     else if (!in.first.isInstanceOf[UnorderedLine])
@@ -147,7 +148,7 @@ class BlockParsers extends Parsers {
 
         items = items ++ Set(
         {
-          if (sublines.length > 0)
+          if (sublines.nonEmpty)
             Seq(
               nodes(new LineReader(TextLine(leading_line.payload) +: sublines)).get
             )
@@ -164,7 +165,7 @@ class BlockParsers extends Parsers {
     }
   }
 
-  val code_node: Parser[Code] = (line(classOf[CodeStartLine]) ~ notLine(classOf[CodeEndLine])
+  lazy val code_node: Parser[Code] = (line(classOf[CodeStartLine]) ~ notLine(classOf[CodeEndLine])
     .+ <~ line(classOf[CodeEndLine])) ^^ {
     case start ~ code =>
       val code_strings = code map {
@@ -177,7 +178,7 @@ class BlockParsers extends Parsers {
       )
   }
 
-  val quote_source: Parser[Seq[InlineNode]] = Parser { in =>
+  lazy val quote_source: Parser[Seq[InlineNode]] = Parser { in =>
     if (!in.first.isInstanceOf[TextLine])
       Failure("not a standard text line", in)
     else if (!in.first.text.startsWith("["))
@@ -194,7 +195,7 @@ class BlockParsers extends Parsers {
       )
   }
 
-  val quote_node: Parser[Quote] = line(classOf[QuoteLine]).+ ~ quote_source.? ^^ {
+  lazy val quote_node: Parser[Quote] = line(classOf[QuoteLine]).+ ~ quote_source.? ^^ {
     case quotes ~ source =>
       Quote(
         InlineParsers.parseAll(
@@ -205,7 +206,7 @@ class BlockParsers extends Parsers {
       )
   }
 
-  val embed_node: Parser[EmbedNode] = line(classOf[EmbedLine]) ^? ({
+  lazy val embed_node: Parser[EmbedNode] = line(classOf[EmbedLine]) ^? ({
     case embed_line if EmbedNode.VALID_EMBED_TYPES.contains(embed_line.arguments.head) =>
       EmbedNode.VALID_EMBED_TYPES.get(embed_line.arguments.head).map(
         f => f(embed_line.arguments.tail, embed_line.meta)
@@ -214,7 +215,7 @@ class BlockParsers extends Parsers {
     s"unrecognized embed type: ${line.arguments.head}; known types: [${EmbedNode.VALID_EMBED_TYPES.keys.mkString(", ")}]"
   })
 
-  val nodes: Parser[Node] = Parser { in =>
+  lazy val nodes: Parser[Node] = Parser { in =>
     if (in.atEnd)
       Failure("end of input", in)
     else {

--- a/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
@@ -205,6 +205,13 @@ class BlockParsers extends Parsers {
       )
   }
 
+  val embed_node: Parser[EmbedNode] = line(classOf[EmbedLine]) ^? ({
+    case embed_line if EmbedNode.VALID_EMBED_TYPES.contains(embed_line.arguments.head) =>
+      EmbedNode.VALID_EMBED_TYPES.get(embed_line.arguments.head).map(
+        f => f(embed_line.arguments.tail, embed_line.meta)
+      ).get
+  }, line => s"unrecognized embed type: ${line.arguments.head}; known types: [${EmbedNode.VALID_EMBED_TYPES.keys.mkString(", ")}]")
+
   val nodes: Parser[Node] = Parser { in =>
     if (in.atEnd)
       Failure("end of input", in)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/BlockParsers.scala
@@ -210,7 +210,9 @@ class BlockParsers extends Parsers {
       EmbedNode.VALID_EMBED_TYPES.get(embed_line.arguments.head).map(
         f => f(embed_line.arguments.tail, embed_line.meta)
       ).get
-  }, line => s"unrecognized embed type: ${line.arguments.head}; known types: [${EmbedNode.VALID_EMBED_TYPES.keys.mkString(", ")}]")
+  }, line => {
+    s"unrecognized embed type: ${line.arguments.head}; known types: [${EmbedNode.VALID_EMBED_TYPES.keys.mkString(", ")}]"
+  })
 
   val nodes: Parser[Node] = Parser { in =>
     if (in.atEnd)
@@ -228,6 +230,8 @@ class BlockParsers extends Parsers {
           code_node(in)
         case l: QuoteLine =>
           quote_node(in)
+        case l: EmbedLine =>
+          embed_node(in)
         case _ =>
           paragraph(in)
       }

--- a/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/InlineParsers.scala
@@ -22,7 +22,7 @@ import com.haaksmash.saxophone.primitives._
 
 import scala.util.parsing.combinator.RegexParsers
 
-object InlineParsers extends RegexParsers {
+object InlineParsers extends UtilParsers {
 
   val FOOTNOTE_START = '{'
   val FOOTNOTE_END = '}'
@@ -47,14 +47,6 @@ object InlineParsers extends RegexParsers {
     MONOSPACE_START -> ("m", MONOSPACE_END),
     RAW_START -> ("r", RAW_END)
   )
-
-  def aChar = Parser { in =>
-    if (in.atEnd) {
-      Failure("End of input reached.", in)
-    } else {
-      Success(in.first, in.rest)
-    }
-  }
 
   def standardText(special: Set[Char]): Parser[StandardText] = Parser { in =>
     if (in.atEnd)
@@ -87,15 +79,6 @@ object InlineParsers extends RegexParsers {
         Success(StandardText(text), in.drop(pos - in.offset))
     }
   }
-
-  val metadata: Parser[Map[String, String]] = "[" ~> ((not("]") ~> aChar).+) <~ "]" ^^ {
-    case metas =>
-      metas.mkString.split('|')
-        .map(metapair => metapair.split(':'))
-        .map(l => l(0) -> l(1))
-        .toMap
-  }
-
   val raw_text: Parser[RawText] = RAW_START ~> ((not(RAW_END) ~> aChar).+) <~ RAW_END ^^ {
     case chars => RawText(chars.mkString)
   }

--- a/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/LineParsers.scala
@@ -62,6 +62,7 @@ class LineParsers extends Parsers {
         case '>' => delegateParsing(line_parsers.quoteParser)(in)
         case '{' => delegateParsing(line_parsers.codeStart)(in)
         case '}' => delegateParsing(line_parsers.codeEnd)(in)
+        case ':' => delegateParsing(line_parsers.embedParser)(in)
         case _ => Failure("no matching start char", in)
       }
 

--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -22,7 +22,7 @@ import com.haaksmash.saxophone.primitives._
 
 
 /**
- * Translates [[String]] to specific instances of [[com.haaksmash.saxophone.Line]]
+ * Translates [[String]] to specific instances of [[com.haaksmash.saxophone.primitives.Line]]
  */
 trait StringLineParsers extends UtilParsers {
 
@@ -32,7 +32,7 @@ trait StringLineParsers extends UtilParsers {
   val QUOTE_LINE = ">>>"
   val EMBED_LINE = ":"
 
-  val headingParser: Parser[HeadingLine] = s"${HEADING_GLYPH}+ ".r ~ rest ^^ {
+  val headingParser: Parser[HeadingLine] = s"$HEADING_GLYPH+ ".r ~ rest ^^ {
     case glyphs ~ text =>
       // glyphs will end with a space that we want to throw away
       HeadingLine(glyphs.trim, text)

--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -30,7 +30,7 @@ trait StringLineParsers extends UtilParsers {
   val CODE_START = "{{{"
   val CODE_END = "}}}"
   val QUOTE_LINE = ">>>"
-  val EMBED_LINE = ":"
+  val EMBED_LINE = "::"
 
   val headingParser: Parser[HeadingLine] = s"$HEADING_GLYPH+ ".r ~ rest ^^ {
     case glyphs ~ text =>
@@ -62,7 +62,7 @@ trait StringLineParsers extends UtilParsers {
 
   val orderedListParser: Parser[OrderedLine] = ("\\d+\\.\\s".r | "- ") ~ rest ^^ {case leader ~ text => OrderedLine(leader.trim, text)}
 
-  val embedParser: Parser[EmbedLine] = (EMBED_LINE ~> restUntil(EMBED_LINE.charAt(0)) <~ EMBED_LINE) ~ metadata.? ^^ {
+  val embedParser: Parser[EmbedLine] = (EMBED_LINE ~> ((not(EMBED_LINE) ~> aChar).+ ^^ (_.mkString)) <~ EMBED_LINE) ~ metadata.? ^^ {
     case text ~ meta =>
       EmbedLine(text.split(" "), text, meta.getOrElse(Map()))}
 

--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -30,6 +30,7 @@ trait StringLineParsers extends UtilParsers {
   val CODE_START = "{{{"
   val CODE_END = "}}}"
   val QUOTE_LINE = ">>>"
+  val EMBED_LINE = ":"
 
   val headingParser: Parser[HeadingLine] = s"${HEADING_GLYPH}+ ".r ~ rest ^^ {
     case glyphs ~ text =>
@@ -60,6 +61,10 @@ trait StringLineParsers extends UtilParsers {
   val unorderedListParser: Parser[UnorderedLine] = "\\*\\s".r ~ rest ^^ {case leader ~ text => UnorderedLine(leader, text)}
 
   val orderedListParser: Parser[OrderedLine] = ("\\d+\\.\\s".r | "- ") ~ rest ^^ {case leader ~ text => OrderedLine(leader.trim, text)}
+
+  val embedParser: Parser[EmbedLine] = (EMBED_LINE ~> restUntil(EMBED_LINE.charAt(0)) <~ EMBED_LINE) ~ metadata.? ^^ {
+    case text ~ meta =>
+      EmbedLine(text.split(" "), text, meta.getOrElse(Map()))}
 
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
@@ -64,7 +64,7 @@ trait UtilParsers extends RegexParsers {
     case metas =>
       metas.mkString.split('|')
         .map(metapair => metapair.split(':'))
-        .map(l => l(0) -> l(1))
+        .map(l => l(0) -> l.slice(1,l.length).mkString(":"))
         .toMap
   }
 

--- a/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/UtilParsers.scala
@@ -35,4 +35,37 @@ trait UtilParsers extends RegexParsers {
       )
     }
   }
+
+  def restUntil(until: Char): Parser[String] = Parser { in =>
+    if (in.atEnd)
+      Success("", in)
+    else {
+      var input = in
+      while (!input.atEnd && !(input.first == until))
+        input = input.rest
+
+      Success(
+        in.source.subSequence(in.offset, input.offset).toString,
+        input
+      )
+    }
+  }
+
+  val aChar = Parser { in =>
+    if (in.atEnd) {
+      Failure("End of input reached.", in)
+    } else {
+      Success(in.first, in.rest)
+    }
+  }
+
+
+  val metadata: Parser[Map[String, String]] = "[" ~> ((not("]") ~> aChar).+) <~ "]" ^^ {
+    case metas =>
+      metas.mkString.split('|')
+        .map(metapair => metapair.split(':'))
+        .map(l => l(0) -> l(1))
+        .toMap
+  }
+
 }

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Lines.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Lines.scala
@@ -36,6 +36,8 @@ case class HeadingLine(prefix: String, text: String) extends Line {
 
 case class TextLine(text: String) extends Line
 
+case class EmbedLine(arguments: Seq[String], text:String, meta:Map[String,String]) extends Line
+
 case class EmptyLine(text: String = "") extends Line
 
 case class CodeStartLine(directives: Map[String, String], text: String = "") extends Line

--- a/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
+++ b/src/main/scala/com/haaksmash/saxophone/primitives/Nodes.scala
@@ -26,6 +26,8 @@ sealed abstract class Node {
   def label_display = s"$label"
 
   override def toString = s"<$label_display>${children.mkString("")}</$label>"
+
+  def meta = Map[String, String]()
 }
 
 case class Document(children: Seq[Node]) extends Node {
@@ -69,6 +71,36 @@ case class Quote(children: Seq[Node], source: Option[Seq[InlineNode]]) extends N
   }
 }
 
+trait EmbedNode extends Node {
+  override val children = Seq.empty
+  def arguments:Seq[String]
+
+  override val label = "embed"
+  override def label_display = {
+    s"$label ${arguments.mkString}"
+  }
+}
+
+object EmbedNode {
+  val VALID_EMBED_TYPES = Map(
+    "image" -> ImageEmbedNode.apply _,
+    "video" -> VideoEmbedNode.apply _,
+    "tweet" -> TweetEmbedNode.apply _
+  )
+}
+
+case class ImageEmbedNode(arguments: Seq[String], override val meta: Map[String, String]) extends EmbedNode {
+  override val label = "image"
+}
+
+case class VideoEmbedNode(arguments: Seq[String], override val meta: Map[String, String]) extends EmbedNode {
+  override val label = "video"
+}
+
+case class TweetEmbedNode(arguments: Seq[String], override val meta: Map[String, String]) extends EmbedNode {
+  override val label = "tweet"
+}
+
 
 sealed abstract class ListNode(items: Traversable[Seq[Node]]) extends Node {
   /**
@@ -90,9 +122,7 @@ case class UnorderedList(items: Set[Seq[Node]]) extends ListNode(items) {
 }
 
 
-trait InlineNode extends Node {
-  def meta = Map[String, String]()
-}
+trait InlineNode extends Node
 
 case class Footnote(children: Seq[InlineNode]) extends InlineNode {
   override val label = "foot"

--- a/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/BaseTranslator.scala
@@ -31,7 +31,7 @@ trait NodeTranslator extends BaseTranslator {
   /**
    * Fallback translator, blindly returns `node.toString`. If we reach
    * this method, something's gone wrong with the translator.
-   * @param node
+   * @param node The node to be translated
    * @return String
    */
   def node(node: Node): String = node.toString
@@ -72,7 +72,9 @@ trait NodeTranslator extends BaseTranslator {
 
   def rawText(node: RawText): String
 
-  def node_to_translator(n: Node) = n match {
+  def embed(node: EmbedNode): String
+
+  def node_to_translator(node: Node) = node match {
     case n: StandardText => standardText(n)
     case n: Link => link(n)
     case n: EmphasizedText => emphasizedText(n)
@@ -88,6 +90,7 @@ trait NodeTranslator extends BaseTranslator {
     case n: RawText => rawText(n)
     case n: Quote => quote(n)
     case n: Footnote => footnote(n)
+    case n: EmbedNode => embed(n)
     case n => this.node(n)
   }
 
@@ -96,7 +99,7 @@ trait NodeTranslator extends BaseTranslator {
     val output = node.children match {
       case Seq() => Traversable(translateSingle(node))
       case children => children map {
-        node_to_translator(_)
+        node_to_translator
       }
     }
     output.mkString

--- a/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
@@ -42,11 +42,11 @@ class GithubMDTranslator extends NodeTranslator {
   def rawText(node: RawText): String = node.text
 
   def unorderedList(node: UnorderedList): String = {
-    ((for (line <- node.items) yield s"* ${line.map(translate(_)).mkString}") mkString "\n") + "\n\n"
+    ((for (line <- node.items) yield s"* ${line.map(translate).mkString}") mkString "\n") + "\n\n"
   }
 
   def orderedList(node: OrderedList): String = {
-    ((for (line <- node.items) yield s"${node.items.indexOf(line) + 1}. ${line.map(translate(_)).mkString}") mkString "\n") + "\n\n"
+    ((for (line <- node.items) yield s"${node.items.indexOf(line) + 1}. ${line.map(translate).mkString}") mkString "\n") + "\n\n"
   }
 
   def weightedText(node: WeightedText): String = s"**${node.text}**"
@@ -66,9 +66,15 @@ class GithubMDTranslator extends NodeTranslator {
   def code(node: Code): String = s"```${node.directives.getOrElse("lang", "")}\n${node.contents}\n```\n"
 
   def embed(node: EmbedNode): String = node match {
-    case ImageEmbedNode(arguments, meta) => s"![${meta.getOrElse("alt", "")}](${arguments.head})"
+    case ImageEmbedNode(arguments, meta) =>
+      val image_out = s"![${meta.getOrElse("alt", "")}](${arguments.head})"
+
+      meta.get("link") match {
+        case Some(link) => s"[$image_out]($link)\n"
+        case None => image_out + "\n"
+      }
     // only support image embeds for GHMD
-    case _ => ""
+    case _ => "\n"
   }
 }
 

--- a/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/GithubMDTranslator.scala
@@ -21,11 +21,11 @@ package com.haaksmash.saxophone.translators
 import com.haaksmash.saxophone.primitives._
 
 class GithubMDTranslator extends NodeTranslator {
-  override def heading(node: Heading): String = s"${"#" * node.level} ${translate(node)}\n"
+  def heading(node: Heading): String = s"${"#" * node.level} ${translate(node)}\n"
 
-  override def footnote(node: Footnote): String = ""
+  def footnote(node: Footnote): String = ""
 
-  override def paragraph(node: Paragraph): String = {
+  def paragraph(node: Paragraph): String = {
     s"${translate(node)}\n\n"
   }
 
@@ -33,37 +33,43 @@ class GithubMDTranslator extends NodeTranslator {
    * Inline nodes; i.e., nodes that don't have children, but only capture
    * meta data about their contents.
    */
-  override def emphasizedText(node: EmphasizedText): String = s"*${node.text}*"
+  def emphasizedText(node: EmphasizedText): String = s"*${node.text}*"
 
-  override def standardText(node: StandardText): String = node.text
+  def standardText(node: StandardText): String = node.text
 
-  override def forcedNewLine(node: ForcedNewline): String = "\n\n"
+  def forcedNewLine(node: ForcedNewline): String = "\n\n"
 
-  override def rawText(node: RawText): String = node.text
+  def rawText(node: RawText): String = node.text
 
-  override def unorderedList(node: UnorderedList): String = {
+  def unorderedList(node: UnorderedList): String = {
     ((for (line <- node.items) yield s"* ${line.map(translate(_)).mkString}") mkString "\n") + "\n\n"
   }
 
-  override def orderedList(node: OrderedList): String = {
+  def orderedList(node: OrderedList): String = {
     ((for (line <- node.items) yield s"${node.items.indexOf(line) + 1}. ${line.map(translate(_)).mkString}") mkString "\n") + "\n\n"
   }
 
-  override def weightedText(node: WeightedText): String = s"**${node.text}**"
+  def weightedText(node: WeightedText): String = s"**${node.text}**"
 
-  override def markedText(node: MarkedText): String = s"${node.text}"
+  def markedText(node: MarkedText): String = s"${node.text}"
 
-  override def struckthroughText(node: StruckthroughText): String = s"~~${node.text}~~"
+  def struckthroughText(node: StruckthroughText): String = s"~~${node.text}~~"
 
-  override def monospacedText(node: MonospaceText): String = {
+  def monospacedText(node: MonospaceText): String = {
     s"`${node.text}`"
   }
 
-  override def link(node: Link): String = s"[${translate(node)}](${node.to.target})"
+  def link(node: Link): String = s"[${translate(node)}](${node.to.target})"
 
-  override def quote(node: Quote): String = s"> ${translate(node)}\n"
+  def quote(node: Quote): String = s"> ${translate(node)}\n"
 
-  override def code(node: Code): String = s"```${node.directives.getOrElse("lang", "")}\n${node.contents}\n```\n"
+  def code(node: Code): String = s"```${node.directives.getOrElse("lang", "")}\n${node.contents}\n```\n"
+
+  def embed(node: EmbedNode): String = node match {
+    case ImageEmbedNode(arguments, meta) => s"![${meta.getOrElse("alt", "")}](${arguments.head})"
+    // only support image embeds for GHMD
+    case _ => ""
+  }
 }
 
 object GithubMDTranslator {

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -96,7 +96,7 @@ class HTMLTranslator(
       case "youtube" =>
         s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/${arguments(1)}?autoplay=0" frameborder="0"></iframe>"""
       case "vimeo" => s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/${arguments(1)}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"""
-      case src => s"""<video>${arguments.map(src => "<source src=\""+src+"\" type=\"video/"+src.split('.').last+"\"")}Whoops, your browser doesn't support the video tag!</video>"""
+      case src => s"""<video>${arguments.map(src => "<source src=\""+src+"\" type=\"video/"+src.split('.').last+"\">").mkString("")}Whoops, your browser doesn't support the video tag!</video>"""
     }
     case TweetEmbedNode(arguments, meta) => s"""<blockquote class="twitter-tweet"><a href="https://twitter.com/${arguments(0)}/status/${arguments(1)}">tweet by @${arguments(0)}</a></blockquote>"""
     case _ => ""

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -94,7 +94,7 @@ class HTMLTranslator(
     case ImageEmbedNode(arguments, meta) => s"""<img src="${arguments.head}" alt="${meta.getOrElse("alt", "")}"/>"""
     case VideoEmbedNode(arguments, meta) => arguments.head match {
       case "youtube" =>
-        s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/${arguments(1)}?autoplay=0" frameborder="0"/>"""
+        s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/${arguments(1)}?autoplay=0" frameborder="0"></iframe>"""
       case "vimeo" => s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/${arguments(1)}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"""
       case src => s"""<video>${arguments.map(src => "<source src=\""+src+"\" type=\"video/"+src.split('.').last+"\"")}Whoops, your browser doesn't support the video tag!</video>"""
     }

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -90,6 +90,18 @@ class HTMLTranslator(
   }
   def rawText(node: RawText) = if (allow_raw_strings) node.text else escapeTextForHTML(node.text)
 
+  def embed(node:EmbedNode) = node match {
+    case ImageEmbedNode(arguments, meta) => s"""<img src="${arguments.head}" alt="${meta.getOrElse("alt", "")}"/>"""
+    case VideoEmbedNode(arguments, meta) => arguments.head match {
+      case "youtube" =>
+        s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/${arguments(1)}?autoplay=0" frameborder="0"/>"""
+      case "vimeo" => s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/${arguments(1)}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"""
+      case src => s"""<video>${arguments.map(src => "<source src=\""+src+"\" type=\"video/"+src.split('.').last+"\"")}Whoops, your browser doesn't support the video tag!</video>"""
+    }
+    case TweetEmbedNode(arguments, meta) => s"""<blockquote class="twitter-tweet"><a href="https://twitter.com/${arguments(0)}/status/${arguments(1)}">tweet by @${arguments(0)}</a></blockquote>"""
+    case _ => ""
+  }
+
 
   override def translate(node: Node): String = {
     val s = super.translate(node)

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -50,7 +50,7 @@ class HTMLTranslator(
   }
 
   def orderedList(node:OrderedList) = {
-    val list_items = node.items.map(li => s"<li>${li.map(translate(_)).mkString}</li>") mkString ""
+    val list_items = node.items.map(li => s"<li>${li.map(translate).mkString}</li>") mkString ""
     if (node.present_unordered)
       s"""<ul>$list_items</ul>"""
     else
@@ -58,7 +58,7 @@ class HTMLTranslator(
   }
 
   def unorderedList(node:UnorderedList) = {
-    val list_items = node.items.map(li => s"""<li>${li.map(translate(_)).mkString}</li>""") mkString ""
+    val list_items = node.items.map(li => s"""<li>${li.map(translate).mkString}</li>""") mkString ""
     s"""<ul>$list_items</ul>"""
   }
 
@@ -67,7 +67,7 @@ class HTMLTranslator(
     if (footnote_as_title_text) {
       footnotes = footnotes :+ ""
       val title_text = translate(node).replaceAll("\"", "\\\\\"")
-      s"""<a title="${title_text}" rel="footnote">$footnote_number</a>"""
+      s"""<a title="$title_text" rel="footnote">$footnote_number</a>"""
     } else {
       footnotes = footnotes :+ translate(node)
       s"""<a href="#note:$footnote_number" name="rn:$footnote_number" rel="footnote">$footnote_number</a>"""
@@ -91,14 +91,22 @@ class HTMLTranslator(
   def rawText(node: RawText) = if (allow_raw_strings) node.text else escapeTextForHTML(node.text)
 
   def embed(node:EmbedNode) = node match {
-    case ImageEmbedNode(arguments, meta) => s"""<img src="${arguments.head}" alt="${meta.getOrElse("alt", "")}"/>"""
+    case ImageEmbedNode(arguments, meta) =>
+      val link_prefix = "link-"
+      val image_out = s"""<img src="${arguments.head}"${convertMetaToHTMLAttrs(meta.filterKeys(!_.startsWith("link")))}/>"""
+      meta.get("link") match {
+        case Some(link) =>
+          val link_meta = meta.filterKeys(_.startsWith(link_prefix)).map{ case (k, v) => k.drop(link_prefix.length) -> v}
+          s"""<a href="$link"${convertMetaToHTMLAttrs(link_meta)}>$image_out</a>"""
+        case None => image_out
+      }
     case VideoEmbedNode(arguments, meta) => arguments.head match {
       case "youtube" =>
         s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/${arguments(1)}?autoplay=0" frameborder="0"></iframe>"""
       case "vimeo" => s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/${arguments(1)}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>"""
       case src => s"""<video>${arguments.map(src => "<source src=\""+src+"\" type=\"video/"+src.split('.').last+"\">").mkString("")}Whoops, your browser doesn't support the video tag!</video>"""
     }
-    case TweetEmbedNode(arguments, meta) => s"""<blockquote class="twitter-tweet"><a href="https://twitter.com/${arguments(0)}/status/${arguments(1)}">tweet by @${arguments(0)}</a></blockquote>"""
+    case TweetEmbedNode(arguments, meta) => s"""<blockquote class="twitter-tweet"><a href="https://twitter.com/${arguments.head}/status/${arguments(1)}">tweet by @${arguments.head}</a></blockquote>"""
     case _ => ""
   }
 
@@ -107,7 +115,7 @@ class HTMLTranslator(
     val s = super.translate(node)
 
     val footer_string = node match {
-      case n:Document if !footnotes.isEmpty && !(footnote_as_title_text) =>
+      case n:Document if footnotes.nonEmpty && !footnote_as_title_text =>
         "<footer>" + footnotes.zipWithIndex.map { case (note, num) => s"""<p><a class="fnote" href="#rn:${num + 1}" name="note:${num + 1}">${num + 1}</a> $note</p>"""}.mkString + "</footer>"
       case _ => ""
     }
@@ -120,7 +128,7 @@ class HTMLTranslator(
    * @param text the string that needs escaping
    * @return escaped version of the input
    */
-  private def escapeTextForHTML(text:String):String = {
+  private def escapeTextForHTML(text:String) = {
     // Order is important here, so we use a ListMap to preserve it.
     val chars_to_escape_sequence = ListMap(
       "&" -> "&amp;", // must be first so we don't accidentally kill anything in the below
@@ -137,6 +145,14 @@ class HTMLTranslator(
     new_text
   }
 
+  /**
+   * Converts a map into html-friendly attributes like you'd see in any HTML tag.
+   * Inserts a leading space FOR YOU if meta is nonEmpty, otherwise returns the
+   * empty string.
+   *
+   * @param meta map of keys to values, like "alt" -> "alternate text"
+   * @return stringified view of meta, like alt="alternate text"
+   */
   private def convertMetaToHTMLAttrs(meta:Map[String, String]): String = {
     val meta_string = meta.map{case (k,v) => s"""$k="$v""""}.mkString(" ")
     if (!meta_string.isEmpty)

--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -76,7 +76,7 @@ class HTMLTranslator(
 
   /*
    * Inline nodes; i.e., nodes that don't have children, but only capture
-   * metadata about their contents.
+   * meta about their contents.
    */
   def link(node:Link) = s"""<a href="${node.to}">${translate(node)}</a>"""
   def emphasizedText(node:EmphasizedText) = s"<em${convertMetaToHTMLAttrs(node.meta)}>${escapeTextForHTML(node.text)}</em>"

--- a/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/SaxophoneTreeStringTranslator.scala
@@ -59,6 +59,8 @@ class SaxophoneTreeStringTranslator extends NodeTranslator {
 
   override def monospacedText(node: MonospaceText): String = ???
 
+  override def embed(node: EmbedNode): String = ???
+
   override def translate(document: Node) = {
     document.toString
   }

--- a/src/test/resources/article_example.sax
+++ b/src/test/resources/article_example.sax
@@ -16,16 +16,23 @@ and an unordered list:
 * no sir!
 * well there's still the implicit order but let's leave that be, shall we?
 
+Ah and now
+- some
+- ordered
+- yet unordered in appearance
+- list items
+
 ## subheading here.
 
 _this text is underlined_, whereas ~this text is struck-through~. *this text is bolded*, whereas /this text is italicized/.
-and |this text is <raw/>| unlike <here>!
+and |this text is <raw/>| unlike <here>! Meanwhile, /this text is red/[style:color:red]
 
 In this paragraph, at long last, we come to the important part: `the code` (this last should appear monospaced).
 
 {{{lang:python|numbers:no
 # directives should appear in the {{{ line above, separated by '|' (pipe) characters.
 
+::image my_image_embedding.jpg::[link:http://yoloyoloyolo.com]
 
 # this should be treated as pre-formatted text; no eating of    whitespace or collapsing of newlines
 # end a code block in the following way: }}}

--- a/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/InlineParsersSpec.scala
@@ -24,13 +24,6 @@ import org.scalatest._
 class InlineParsersSpec extends FlatSpec {
   val parsers = InlineParsers
 
-  "metadata" should "match things between '[]'" in {
-    val input = "[some:stuff|that:makes|meta:data]"
-    val result = parsers.parseAll(parsers.metadata, input).get
-
-    assert(result == Map("some" -> "stuff", "that" -> "makes", "meta" -> "data"))
-  }
-
   "standardText" should "match a regular sentence" in {
     val input = "some regular old input"
     val result = parsers.parseAll(parsers.standardText(Set()), input).get
@@ -94,7 +87,7 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "hello")
   }
 
-  it should "support metadata" in {
+  it should "support meta" in {
     val input = "/hello/[class:red]"
     val result = parsers.parseAll(parsers.emphasized_text, input).get
 
@@ -109,7 +102,7 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "hello")
   }
 
-  it should "support metadata" in {
+  it should "support meta" in {
     val input = "*hello*[class:red]"
     val result = parsers.parseAll(parsers.weighted_text, input).get
 
@@ -124,7 +117,7 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "hello")
   }
 
-  it should "support metadata" in {
+  it should "support meta" in {
     val input = "_hello_[class:red]"
     val result = parsers.parseAll(parsers.marked_text, input).get
 
@@ -139,7 +132,7 @@ class InlineParsersSpec extends FlatSpec {
     assert(result.text == "hello")
   }
 
-  it should "support metadata" in {
+  it should "support meta" in {
     val input = "~hello~[class:red]"
     val result = parsers.parseAll(parsers.struckthrough_text, input).get
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -107,15 +107,15 @@ class StringLineParserSpec extends FlatSpec {
   }
 
   "embed_line" should "match a line that starts with :" in {
-    val input = ":image myhumbs.jpg \"nobody move\":"
+    val input = "::image http://haaksmash.com/myhumbs.jpg \"nobody move\"::"
     val embed_line = parsers.parseAll(parsers.embedParser, input).get
 
-    assert(embed_line.text == "image myhumbs.jpg \"nobody move\"")
-    assert(embed_line.arguments == Seq("image", "myhumbs.jpg", "\"nobody", "move\""))
+    assert(embed_line.text == "image http://haaksmash.com/myhumbs.jpg \"nobody move\"")
+    assert(embed_line.arguments == Seq("image", "http://haaksmash.com/myhumbs.jpg", "\"nobody", "move\""))
   }
 
   it should "support meta" in {
-    val input = ":image myhumbs.jpg \"nobody move\":[class:red]"
+    val input = "::image myhumbs.jpg \"nobody move\"::[class:red]"
     val embed_line = parsers.parseAll(parsers.embedParser, input).get
 
     assert(embed_line.text == "image myhumbs.jpg \"nobody move\"")

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -105,4 +105,21 @@ class StringLineParserSpec extends FlatSpec {
 
     assert(the_line.isEmpty)
   }
+
+  "embed_line" should "match a line that starts with :" in {
+    val input = ":image myhumbs.jpg \"nobody move\":"
+    val embed_line = parsers.parseAll(parsers.embedParser, input).get
+
+    assert(embed_line.text == "image myhumbs.jpg \"nobody move\"")
+    assert(embed_line.arguments == Seq("image", "myhumbs.jpg", "\"nobody", "move\""))
+  }
+
+  it should "support meta" in {
+    val input = ":image myhumbs.jpg \"nobody move\":[class:red]"
+    val embed_line = parsers.parseAll(parsers.embedParser, input).get
+
+    assert(embed_line.text == "image myhumbs.jpg \"nobody move\"")
+    assert(embed_line.arguments == Seq("image", "myhumbs.jpg", "\"nobody", "move\""))
+    assert(embed_line.meta == Map("class" -> "red"))
+  }
 }

--- a/src/test/scala/com/haaksmash/saxophone/parsers/UtilParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/UtilParserSpec.scala
@@ -37,11 +37,18 @@ class UtilParserSpec extends FlatSpec {
 
   }
 
-  "meta" should "match things between '[]'" in {
+  "metadata" should "match things between '[]'" in {
     val input = "[some:stuff|that:makes|meta:data]"
     val result = parsers.parseAll(parsers.metadata, input).get
 
     assert(result == Map("some" -> "stuff", "that" -> "makes", "meta" -> "data"))
+  }
+
+  it should "only take the first of a : pair" in {
+    val input = "[style:color:red;font-weight:bold;]"
+    val result = parsers.parseAll(parsers.metadata, input).get
+
+    assert(result == Map("style" -> "color:red;font-weight:bold;"))
   }
 
 

--- a/src/test/scala/com/haaksmash/saxophone/parsers/UtilParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/UtilParserSpec.scala
@@ -37,4 +37,12 @@ class UtilParserSpec extends FlatSpec {
 
   }
 
+  "meta" should "match things between '[]'" in {
+    val input = "[some:stuff|that:makes|meta:data]"
+    val result = parsers.parseAll(parsers.metadata, input).get
+
+    assert(result == Map("some" -> "stuff", "that" -> "makes", "meta" -> "data"))
+  }
+
+
 }

--- a/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
@@ -119,14 +119,21 @@ class GithubMDTranslatorSpec extends FlatSpec {
     val embed = ImageEmbedNode(Seq("helloooo"), Map())
     val result = translator.embed(embed)
 
-    assert(result == "![](helloooo)")
+    assert(result == "![](helloooo)\n")
   }
 
   it should "include alt text if present" in {
     val embed = ImageEmbedNode(Seq("helloooo"), Map("alt" -> "an image"))
     val result = translator.embed(embed)
 
-    assert(result == "![an image](helloooo)")
+    assert(result == "![an image](helloooo)\n")
+  }
+
+  it should "make the shit a link if asked" in {
+    val embed = ImageEmbedNode(Seq("helloooo"), Map("link" -> "an image"))
+    val result = translator.embed(embed)
+
+    assert(result == "[![](helloooo)](an image)\n")
   }
 
   it should "ignore non-image embeds" in {
@@ -134,7 +141,7 @@ class GithubMDTranslatorSpec extends FlatSpec {
     val embed = VideoEmbedNode(Seq("helloooo"), Map("alt" -> "an image"))
     val result = translator.embed(embed)
 
-    assert(result == "")
+    assert(result == "\n")
   }
 
   "link" should "translate a Link" in {

--- a/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/GithubMDTranslatorSpec.scala
@@ -115,6 +115,28 @@ class GithubMDTranslatorSpec extends FlatSpec {
     assert(result contains "* Line Three\n")
   }
 
+  "embed" should "translate an EmbedNode" in {
+    val embed = ImageEmbedNode(Seq("helloooo"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == "![](helloooo)")
+  }
+
+  it should "include alt text if present" in {
+    val embed = ImageEmbedNode(Seq("helloooo"), Map("alt" -> "an image"))
+    val result = translator.embed(embed)
+
+    assert(result == "![an image](helloooo)")
+  }
+
+  it should "ignore non-image embeds" in {
+
+    val embed = VideoEmbedNode(Seq("helloooo"), Map("alt" -> "an image"))
+    val result = translator.embed(embed)
+
+    assert(result == "")
+  }
+
   "link" should "translate a Link" in {
     val link = Link(Seq(StandardText("the link!")), LinkTarget("the target"))
 

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -148,7 +148,7 @@ class HTMLTranslatorSpec extends FlatSpec {
     val embed = VideoEmbedNode(Seq("youtube", "the_video_id"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/the_video_id?autoplay=0" frameborder="0"/>""")
+    assert(result == s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/the_video_id?autoplay=0" frameborder="0"></iframe>""")
   }
 
   it should "recognize (vimeo) VideoEmbedNodes" in {

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -158,6 +158,13 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/the_video_id" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>""")
   }
 
+  it should "fallback when video isn't a special type" in {
+    val embed = VideoEmbedNode(Seq("some_src.mp4", "some_src.ogg"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == s"""<video><source src="some_src.mp4" type="video/mp4"><source src="some_src.ogg" type="video/ogg">Whoops, your browser doesn't support the video tag!</video>""")
+  }
+
   it should "recognize TweetEmbedNodes" in {
     val embed = TweetEmbedNode(Seq("username", "tweetid"), Map())
     val result = translator.embed(embed)

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -141,42 +141,42 @@ class HTMLTranslatorSpec extends FlatSpec {
     val embed = ImageEmbedNode(Seq("some source here"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<img src="${embed.arguments.head}"/>""")
+    assert(result == s"""<figure class="image"><img src="${embed.arguments.head}"/></figure>""")
   }
 
   it should "put links and alts in the right place" in {
     val embed = ImageEmbedNode(Seq("some source here"), Map("alt" -> "alt text", "link" -> "linkylinky", "link-class" -> "image"))
     val result = translator.embed(embed)
 
-    assert(result == s"""<a href="linkylinky" class="image"><img src="${embed.arguments.head}" alt="alt text"/></a>""")
+    assert(result == s"""<figure class="image"><a href="linkylinky" class="image"><img src="${embed.arguments.head}" alt="alt text"/></a></figure>""")
   }
 
   it should "recognize (youtube) VideoEmbedNodes" in {
     val embed = VideoEmbedNode(Seq("youtube", "the_video_id"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/the_video_id?autoplay=0" frameborder="0"></iframe>""")
+    assert(result == s"""<figure class="video"><iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/the_video_id?autoplay=0" frameborder="0"></iframe></figure>""")
   }
 
   it should "recognize (vimeo) VideoEmbedNodes" in {
     val embed = VideoEmbedNode(Seq("vimeo", "the_video_id"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/the_video_id" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>""")
+    assert(result == s"""<figure class="video"><iframe class="vimeoplayer" src="https://player.vimeo.com/video/the_video_id" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></figure>""")
   }
 
   it should "fallback when video isn't a special type" in {
     val embed = VideoEmbedNode(Seq("some_src.mp4", "some_src.ogg"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<video><source src="some_src.mp4" type="video/mp4"><source src="some_src.ogg" type="video/ogg">Whoops, your browser doesn't support the video tag!</video>""")
+    assert(result == s"""<figure class="video"><video><source src="some_src.mp4" type="video/mp4"><source src="some_src.ogg" type="video/ogg">Whoops, your browser doesn't support the video tag!</video></figure>""")
   }
 
   it should "recognize TweetEmbedNodes" in {
     val embed = TweetEmbedNode(Seq("username", "tweetid"), Map())
     val result = translator.embed(embed)
 
-    assert(result == "<blockquote class=\"twitter-tweet\"><a href=\"https://twitter.com/username/status/tweetid\">tweet by @username</a></blockquote>")
+    assert(result == "<figure class=\"tweet\"><blockquote class=\"twitter-tweet\"><a href=\"https://twitter.com/username/status/tweetid\">tweet by @username</a></blockquote></figure>")
   }
 
   "link" should "translate a Link" in {

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -141,7 +141,14 @@ class HTMLTranslatorSpec extends FlatSpec {
     val embed = ImageEmbedNode(Seq("some source here"), Map())
     val result = translator.embed(embed)
 
-    assert(result == s"""<img src="${embed.arguments.head}" alt=""/>""")
+    assert(result == s"""<img src="${embed.arguments.head}"/>""")
+  }
+
+  it should "put links and alts in the right place" in {
+    val embed = ImageEmbedNode(Seq("some source here"), Map("alt" -> "alt text", "link" -> "linkylinky", "link-class" -> "image"))
+    val result = translator.embed(embed)
+
+    assert(result == s"""<a href="linkylinky" class="image"><img src="${embed.arguments.head}" alt="alt text"/></a>""")
   }
 
   it should "recognize (youtube) VideoEmbedNodes" in {

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -137,6 +137,34 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result contains "<li>Line Three</li>")
   }
 
+  "embed" should "recognize ImageEmbedNodes" in {
+    val embed = ImageEmbedNode(Seq("some source here"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == s"""<img src="${embed.arguments.head}" alt=""/>""")
+  }
+
+  it should "recognize (youtube) VideoEmbedNodes" in {
+    val embed = VideoEmbedNode(Seq("youtube", "the_video_id"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == s"""<iframe id="ytplayer" class="ytplayer" type="text/html" src="http://www.youtube.com/embed/the_video_id?autoplay=0" frameborder="0"/>""")
+  }
+
+  it should "recognize (vimeo) VideoEmbedNodes" in {
+    val embed = VideoEmbedNode(Seq("vimeo", "the_video_id"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == s"""<iframe class="vimeoplayer" src="https://player.vimeo.com/video/the_video_id" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>""")
+  }
+
+  it should "recognize TweetEmbedNodes" in {
+    val embed = TweetEmbedNode(Seq("username", "tweetid"), Map())
+    val result = translator.embed(embed)
+
+    assert(result == "<blockquote class=\"twitter-tweet\"><a href=\"https://twitter.com/username/status/tweetid\">tweet by @username</a></blockquote>")
+  }
+
   "link" should "translate a Link" in {
     val link = Link(Seq(StandardText("the link!")), LinkTarget("the target"))
 

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -161,7 +161,7 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == "<em>IMPORTANT!</em>")
   }
 
-  it should "honor metadata" in {
+  it should "honor meta" in {
     val text = EmphasizedText("IMPORTANT!", Map("class" -> "red"))
 
     val result = translator.emphasizedText(text)
@@ -197,7 +197,7 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result.contains("&amp;"))
   }
 
-  it should "honor metadata" in {
+  it should "honor meta" in {
     val text = WeightedText(1, "HEAVY!", Map("class" -> "red"))
 
     val result = translator.weightedText(text)
@@ -239,7 +239,7 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result == "<mark>defective link</mark>")
   }
 
-  it should "honor metadata" in {
+  it should "honor meta" in {
     val text = MarkedText("defective link", Map("class" -> "red"))
 
     val result = translator.markedText(text)
@@ -297,7 +297,7 @@ class HTMLTranslatorSpec extends FlatSpec {
     assert(result.contains("&amp;"))
   }
 
-  it should "honor metadata" in {
+  it should "honor meta" in {
     val text = MonospaceText("defective link", Map("class" -> "red"))
 
     val result = translator.monospacedText(text)


### PR DESCRIPTION
the only way to get an image in right now is to do a `|<img />|` raw-text section, which will wrap the whole thing in a paragraph --- not always desirable, and certainly not a flexible way to go about it.

This would introduce a new block: possibly indicated with a leading `:`. A grammar like `:<type--of-embed> <args> <for> <embed>:`

```
Look at this pretty figure:
:image the_image_we_need.jpg:
```

requiring a terminal `:` allows metadata to be added per #8 

Translators will have to make some choices about how to handle types that they don't support directly --- `HTMLTranslator` probably won't handle `figure`, for example. It might be best to give them an option to coerce to some default on unrecognized types of embeds, with the default being to complain.
