### PR TITLE
no need for quotes to start with >>> instead of >

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
+++ b/src/main/scala/com/haaksmash/saxophone/parsers/StringLineParsers.scala
@@ -29,7 +29,7 @@ trait StringLineParsers extends UtilParsers {
   val HEADING_GLYPH = "#"
   val CODE_START = "{{{"
   val CODE_END = "}}}"
-  val QUOTE_LINE = ">>>"
+  val QUOTE_LINE = ">"
   val EMBED_LINE = "::"
 
   val headingParser: Parser[HeadingLine] = s"$HEADING_GLYPH+ ".r ~ rest ^^ {

--- a/src/test/resources/article_example.sax
+++ b/src/test/resources/article_example.sax
@@ -40,12 +40,12 @@ In this paragraph, at long last, we come to the important part: `the code` (this
 
 and finally, we'll end with a little quote from a well-known fictional character:
 
->>> I'm just gonna take Sundays off for the _rest of time_. You should too!
->>> lolololol
+> I'm just gonna take Sundays off for the _rest of time_. You should too!
+> lolololol
 [source: God]
 
->>> And another quote
->>> on multiple lines
+> And another quote
+> on multiple lines
 followed by text??
 
 God should be pictured here, for those of you who haven't seen God (all of you): [path/to/some/file.jpg]

--- a/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/parsers/StringlineParserSpec.scala
@@ -55,14 +55,14 @@ class StringLineParserSpec extends FlatSpec {
   }
 
   "quote_line" should "match >>>" in {
-    val input = ">>> a quote goes here"
+    val input = "> a quote goes here"
     val quote_line = parsers.parseAll(parsers.quoteParser, input).get
 
     assert(quote_line.payload == "a quote goes here")
   }
 
   it should "require a following space" in {
-    val input = ">>>not quote"
+    val input = ">not quote"
     val the_line = parsers.parseAll(parsers.quoteParser, input)
 
     assert(the_line.isEmpty)


### PR DESCRIPTION
Don't even remember why I chose this? To be explicit as possible, maybe? makes no sense.
