### PR TITLE
HTMLTranslator - quote is translated too verbosely

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -44,9 +44,9 @@ class HTMLTranslator(
 
   def quote(node:Quote) = {
     if (node.source.isDefined)
-      s"""<figure class="quote"><blockquote>${translate(node)}</blockquote><figcaption>${node.source.get.map(translate(_)).mkString}</figcaption></figure>"""
+      s"""<blockquote>${translate(node)}<footer>${node.source.get.map(translate(_)).mkString}</footer></blockquote>"""
     else
-      s"""<figure class="quote"><blockquote>${translate(node)}</blockquote></figure>"""
+      s"""<blockquote>${translate(node)}</blockquote>"""
   }
 
   def orderedList(node:OrderedList) = {

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -30,7 +30,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.quote(quote)
 
-    assert(result == "<figure class=\"quote\"><blockquote>Hello, Clarice.</blockquote></figure>")
+    assert(result == "<blockquote>Hello, Clarice.</blockquote>")
   }
 
   it should "translate a Quote with a source" in {
@@ -38,7 +38,7 @@ class HTMLTranslatorSpec extends FlatSpec {
 
     val result = translator.quote(quote)
 
-    assert(result == "<figure class=\"quote\"><blockquote>Hello, Clarice.</blockquote><figcaption>Silence of the Lambs</figcaption></figure>")
+    assert(result == "<blockquote>Hello, Clarice.<footer>Silence of the Lambs</footer></blockquote>")
   }
 
   "heading" should "translate a Heading" in {


### PR DESCRIPTION
See http://html5doctor.com/cite-and-blockquote-reloaded/, it can just be a `<blockquote>` with an optional `<footer>` if there's a source.
