### PR TITLE
metadata in HTMLTranslator should be escaped

### DIFF
--- a/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
+++ b/src/main/scala/com/haaksmash/saxophone/translators/HTMLTranslator.scala
@@ -175,7 +175,9 @@ class HTMLTranslator(
    * @return stringified view of meta, like alt="alternate text"
    */
   private def convertMetaToHTMLAttrs(meta:Map[String, String]): String = {
-    val meta_string = meta.map{case (k,v) => s"""$k="$v""""}.mkString(" ")
+    val meta_string = meta.map{
+      case (k,v) => s"""$k="${v.replaceAll("\"", "\\\\\"")}""""
+    }.mkString(" ")
     if (!meta_string.isEmpty)
       " " + meta_string
     else

--- a/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
+++ b/src/test/scala/com/haaksmash/saxophone/translators/HTMLTranslatorSpec.scala
@@ -145,10 +145,10 @@ class HTMLTranslatorSpec extends FlatSpec {
   }
 
   it should "put links and alts in the right place" in {
-    val embed = ImageEmbedNode(Seq("some source here"), Map("alt" -> "alt text", "link" -> "linkylinky", "link-class" -> "image"))
+    val embed = ImageEmbedNode(Seq("some source here"), Map("alt" -> "alt \"text", "link" -> "linkylinky", "link-class" -> "image"))
     val result = translator.embed(embed)
 
-    assert(result == s"""<figure class="image"><a href="linkylinky" class="image"><img src="${embed.arguments.head}" alt="alt text"/></a></figure>""")
+    assert(result == s"""<figure class="image"><a href="linkylinky" class="image"><img src="${embed.arguments.head}" alt="alt \\"text"/></a></figure>""")
   }
 
   it should "recognize (youtube) VideoEmbedNodes" in {


### PR DESCRIPTION
```
::image lololol.jpg::[alt:this will" onLoad="alert();]
```

will not be translated accurately: 

```
<img src="lololol.jpg" alt="this will" onLoad="alert();"/>
```
